### PR TITLE
Add --no-ble flag to prevent AC toggle issue on E300LFP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to pecron-monitor are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [0.5.1] — 2026-02-25
+
+### Added
+- `--no-ble` flag to disable Bluetooth transport entirely
+- Per-device `ble: false` config option to disable BLE for specific devices
+- Log message when BLE is disabled
+
+### Fixed
+- E300LFP AC output being toggled off intermittently when BLE is enabled (#3) — BLE connection appears to cause firmware side effects on some models; `--no-ble` or `ble: false` provides a workaround
+
 ## [0.5.0] — 2026-02-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.5.0** · [Changelog](CHANGELOG.md)
+**v0.5.1** · [Changelog](CHANGELOG.md)
 
 Real-time monitoring and control for Pecron portable power stations — no phone required.
 

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -18,7 +18,7 @@ Usage:
     python pecron_monitor.py --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 import argparse
 import base64
@@ -675,7 +675,7 @@ class HomeAssistantBridge:
 # ===========================================================================
 
 class PecronMonitor:
-    def __init__(self, config: dict):
+    def __init__(self, config: dict, no_ble: bool = False):
         self.config = config
         self.region = REGIONS[config["region"]]
         self.token_data = None
@@ -690,6 +690,7 @@ class PecronMonitor:
         self.local_transports = {}  # device_key → LocalTransport
         self.ble_transports = {}   # device_key → BLETransport
         self.offline_mode = False  # Set to True when running in local-only mode
+        self.no_ble = no_ble  # Skip BLE transport entirely
 
         # Automation rules
         self.rules = config.get("rules", [])
@@ -804,10 +805,16 @@ class PecronMonitor:
                     log.warning("Failed to set up local transport for %s: %s", dk, e)
 
         # Set up BLE transports
-        if HAS_BLE:
+        if self.no_ble:
+            log.info("BLE disabled (--no-ble flag)")
+        if HAS_BLE and not self.no_ble:
             for device in self.devices:
                 dk = device["device_key"]
                 cfg = configured.get(dk, {})
+                # Per-device BLE disable: set ble: false in config.yaml
+                if cfg.get("ble") is False:
+                    log.info("BLE disabled for %s (ble: false in config)", dk)
+                    continue
                 ble_addr = cfg.get("ble_address")
                 ble_enabled = cfg.get("ble", False)
                 if not ble_addr and not ble_enabled:
@@ -1690,6 +1697,8 @@ def main():
     parser.add_argument("--setup", action="store_true", help="Run setup wizard")
     parser.add_argument("--local", action="store_true",
                         help="Run in offline/local-only mode (no cloud, uses cached config)")
+    parser.add_argument("--no-ble", action="store_true",
+                        help="Disable Bluetooth (BLE) transport — use WiFi TCP or cloud only")
     parser.add_argument("--status", action="store_true", help="One-shot status check")
     parser.add_argument("--ac", choices=["on", "off"], help="Turn AC output on/off")
     parser.add_argument("--dc", choices=["on", "off"], help="Turn DC output on/off")
@@ -1722,7 +1731,7 @@ def main():
     with open(config_path) as f:
         config = yaml.safe_load(f)
 
-    monitor = PecronMonitor(config)
+    monitor = PecronMonitor(config, no_ble=args.no_ble)
 
     def _signal_handler(sig, frame):
         monitor.stop()
@@ -1748,7 +1757,7 @@ def main():
         return
 
     if args.raw:
-        monitor = PecronMonitor(config)
+        monitor = PecronMonitor(config, no_ble=args.no_ble)
         monitor.authenticate()
         monitor.connect_mqtt()
         time.sleep(3)
@@ -1775,7 +1784,7 @@ def main():
             except ValueError:
                 print(f"Invalid value: {val}")
                 sys.exit(1)
-        monitor = PecronMonitor(config)
+        monitor = PecronMonitor(config, no_ble=args.no_ble)
         monitor.authenticate()
         monitor.connect_mqtt()
         time.sleep(3)
@@ -1858,7 +1867,7 @@ def main():
         # Step 4: MQTT test
         print("\n4. MQTT connectivity test...")
         print("   Connecting and waiting 15 seconds for data...\n")
-        monitor = PecronMonitor(config)
+        monitor = PecronMonitor(config, no_ble=args.no_ble)
         monitor.authenticate()
         monitor.connect_mqtt()
         time.sleep(3)


### PR DESCRIPTION
## Problem

Some Pecron models (E300LFP reported) have their AC output toggled off intermittently when the script connects via Bluetooth. The user can see the AC switch flip in the Pecron app.

## Root Cause Analysis

After tracing the protocol, **our script never sends control commands (0x0013) during `--status`**. It only sends:
- `0x7032` / `0x7034` — BLE handshake (request random + login)
- `0x0011` — read status

The issue appears to be a **firmware side effect** on the E300LFP where the BLE connection/handshake triggers an output state reset. This is intermittent and model-specific.

## Fix

- `--no-ble` CLI flag to skip BLE transport entirely
- Per-device `ble: false` in config.yaml to disable BLE for specific devices
- Clear logging when BLE is disabled

This gives users a workaround while the root cause is in Pecron's firmware.

## Example

```bash
# Skip BLE globally
python pecron_monitor.py --status --no-ble

# Or disable per-device in config.yaml
devices:
  - device_key: ACD9296AD407
    ble: false  # Disable BLE for this device
```

Addresses #3