### PR TITLE
fix: retry cloud login + HA MQTT instead of stranding in offline mode (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to pecron-monitor are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [0.7.1] — 2026-04-19
+
+### Fixed
+- **Cloud login failure no longer strands the monitor in offline mode forever** (#23). When a token refresh hits a transient network error (DNS outage, router reboot, ISP blip, etc.), the monitor falls back to offline mode as before — but now retries cloud re-login every `cloud_retry_interval` seconds (default: 300s). On a successful retry, MQTT is reconnected and local transports are refreshed automatically. User-requested `--offline` runs are never retried.
+- **Home Assistant MQTT bridge now retries a failed initial connection** (#23 follow-up). If the local MQTT broker is down when the monitor starts, the bridge attempts to reconnect every `homeassistant.retry_interval` seconds (default: 60s) instead of giving up permanently. `paho-mqtt`'s built-in auto-reconnect already handles drops after an established connection; this fix closes the startup gap.
+
+### Added
+- Two config knobs (both optional, safe defaults):
+  - `cloud_retry_interval` at the top level — seconds between cloud recovery attempts.
+  - `homeassistant.retry_interval` — seconds between HA broker reconnect attempts.
+
 ## [0.7.0] — 2026-04-04
 
 ### Added

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -33,6 +33,12 @@ class HomeAssistantBridge:
         self.discovery_prefix = ha_config.get("discovery_prefix", "homeassistant")
         self._connected = False
 
+        # Retry state for the local MQTT broker (issue #23 follow-up).
+        # If the broker is down at startup or drops later, try_reconnect() called
+        # from the main loop will attempt a fresh connect every _retry_interval seconds.
+        self._last_retry_at = 0.0
+        self._retry_interval = ha_config.get("retry_interval", 60)
+
         # Cache last-known-good values per device so partial payloads don't zero-out entities
         self._state_cache = {}  # device_key -> dict of last published fields
         # Cache last-known values per device so partial payloads (host-only vs SOC-only)
@@ -40,17 +46,32 @@ class HomeAssistantBridge:
         self._last_state = {}  # device_key -> dict
 
     def connect(self):
+        """Initial connection attempt. If it fails the bridge is not fatal —
+        the monitor's main loop will call try_reconnect() periodically."""
+        self._last_retry_at = time.time()
+        self._connect_attempt()
+
+    def _connect_attempt(self):
         host = self.ha_config.get("mqtt_host", "localhost")
         port = self.ha_config.get("mqtt_port", 1883)
         user = self.ha_config.get("mqtt_user", "")
         pw = self.ha_config.get("mqtt_password", "")
 
-        self.client = mqtt.Client(
+        # Tear down any previous client before a fresh attempt.
+        if self.client is not None:
+            try:
+                self.client.loop_stop()
+                self.client.disconnect()
+            except Exception:
+                pass
+            self.client = None
+
+        client = mqtt.Client(
             client_id="pecron_ha_bridge",
             callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
         )
         if user:
-            self.client.username_pw_set(user, pw)
+            client.username_pw_set(user, pw)
 
         def on_connect(client, ud, flags, rc, props=None):
             if rc == mqtt.CONNACK_ACCEPTED:
@@ -63,6 +84,13 @@ class HomeAssistantBridge:
                     for ctrl in ["ac", "dc", "ups"]:
                         client.subscribe(f"pecron/{dk}/{ctrl}/set", qos=1)
 
+        def on_disconnect(client, ud, disconnect_flags, rc, props=None):
+            # paho auto-reconnect handles this after a successful initial connect,
+            # but we flip the flag so try_reconnect() is a no-op until paho gives up.
+            if self._connected:
+                log.warning("Home Assistant MQTT bridge disconnected (rc=%s)", rc)
+            self._connected = False
+
         def on_message(client, ud, msg):
             # Handle HA commands
             parts = msg.topic.split("/")
@@ -72,16 +100,37 @@ class HomeAssistantBridge:
                 payload = msg.payload.decode().upper()
                 self._handle_command(dk, ctrl, payload)
 
-        self.client.on_connect = on_connect
-        self.client.on_message = on_message
+        client.on_connect = on_connect
+        client.on_disconnect = on_disconnect
+        client.on_message = on_message
+        client.reconnect_delay_set(min_delay=1, max_delay=self._retry_interval)
         try:
-            self.client.connect(host, port)
-            self.client.loop_start()
+            client.connect(host, port)
+            client.loop_start()
+            self.client = client
         except (ConnectionRefusedError, OSError) as e:
-            log.error("Cannot connect to MQTT broker at %s:%d — %s. HA bridge disabled.", host, port, e)
-            log.error("Install mosquitto or disable homeassistant.enabled in config.yaml")
+            log.error("Cannot connect to MQTT broker at %s:%d — %s. Will retry every %ds.",
+                      host, port, e, self._retry_interval)
             self._connected = False
-            return
+            self.client = None
+
+    def try_reconnect(self) -> bool:
+        """Retry the initial HA MQTT connection if it never succeeded.
+        No-op once paho's auto-reconnect is handling an already-established session.
+        Returns True when a retry attempt ran (regardless of outcome).
+        """
+        if self._connected:
+            return False
+        if self.client is not None:
+            # paho is already trying in the background; don't fight it.
+            return False
+        now = time.time()
+        if now - self._last_retry_at < self._retry_interval:
+            return False
+        self._last_retry_at = now
+        log.info("Retrying Home Assistant MQTT connection...")
+        self._connect_attempt()
+        return True
 
     def _handle_command(self, device_key: str, control: str, payload: str):
         """Called when HA sends a command. Delegates to the monitor."""

--- a/monitor.py
+++ b/monitor.py
@@ -70,6 +70,12 @@ class PecronMonitor:
         # Option to skip setting up local transports (set by authenticate skip_local)
         self.skip_local_setup = False
 
+        # Cloud recovery state (issue #23). _fell_back_to_offline distinguishes
+        # an unplanned fallback (transient DNS/network failure during cloud login)
+        # from a user-requested offline run — only the former should be retried.
+        self._fell_back_to_offline = False
+        self._last_cloud_retry_at = 0.0
+
     def _next_packet_id(self) -> int:
         self._packet_id = (self._packet_id + 1) % 65535
         return self._packet_id
@@ -145,6 +151,7 @@ class PecronMonitor:
                     "Run --setup first to fetch and cache these credentials."
                 )
             self.offline_mode = True
+            self._fell_back_to_offline = False  # user-requested; no cloud retry
             log.info("🔒 OFFLINE MODE — using cached credentials from config.yaml")
             self._build_devices_from_config()
         elif not force_offline and can_offline:
@@ -159,9 +166,13 @@ class PecronMonitor:
                     raise RuntimeError("No valid devices found.")
                 if not self.skip_local_setup:
                     self._setup_local_transports()
+                self.offline_mode = False
+                self._fell_back_to_offline = False
             except Exception as e:
                 log.warning("Cloud login failed (%s), falling back to offline mode", e)
                 self.offline_mode = True
+                self._fell_back_to_offline = True  # issue #23: retry periodically
+                self._last_cloud_retry_at = time.time()
                 self._build_devices_from_config()
         else:
             # Normal cloud-first mode
@@ -1167,6 +1178,48 @@ class PecronMonitor:
             return True
         return time.time() > (self.token_data["expires_at"] - 300)
 
+    def _try_cloud_recovery(self) -> bool:
+        """Retry cloud login after a prior transient failure (issue #23).
+
+        Only triggers when we're in offline_mode AND the fallback was unplanned
+        (not --offline). On success, rejoins cloud MQTT and clears the flag.
+        """
+        if not self.offline_mode or not self._fell_back_to_offline:
+            return False
+        interval = self.config.get("cloud_retry_interval", 300)
+        now = time.time()
+        if now - self._last_cloud_retry_at < interval:
+            return False
+        self._last_cloud_retry_at = now
+
+        # Phase 1: prove cloud is reachable before mutating any state.
+        try:
+            log.info("Retrying cloud login (offline recovery)...")
+            token = login(self.config["email"], self.config["password"], self.region)
+            devices = resolve_devices(self.config, token["token"], self.region)
+            if not devices:
+                raise RuntimeError("Cloud login succeeded but no devices resolved")
+        except Exception as e:
+            log.info("Cloud retry failed: %s (next attempt in %ds)", e, interval)
+            return False
+
+        # Phase 2: login succeeded — apply state and rebuild MQTT/local transports.
+        self.token_data = token
+        self.devices = devices
+        self.offline_mode = False
+        self._fell_back_to_offline = False
+        log.info("Cloud recovered — reconnecting MQTT")
+        try:
+            if not self.skip_local_setup:
+                self._setup_local_transports()
+            self.connect_mqtt()
+        except Exception as e:
+            # A post-login MQTT/local failure shouldn't wedge us back in offline mode,
+            # but log loudly so operators see it. paho's auto-reconnect + the HA retry
+            # loop will recover on their own.
+            log.warning("Cloud recovered but MQTT/local setup hit an error: %s", e)
+        return True
+
     # --- MQTT connection ---
 
     def connect_mqtt(self):
@@ -1249,6 +1302,16 @@ class PecronMonitor:
                     self.authenticate(force_offline=force_offline)
                     self.connect_mqtt()
                     time.sleep(3)
+                else:
+                    # Issue #23: if we previously fell back to offline due to a
+                    # transient cloud failure, periodically attempt to recover.
+                    self._try_cloud_recovery()
+
+                # Issue #23 (secondary): retry local HA MQTT if it failed to
+                # connect at startup or was lost.
+                if self.ha_bridge:
+                    self.ha_bridge.try_reconnect()
+
                 self._request_status()
         except KeyboardInterrupt:
             log.info("Shutting down...")

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     python pecron_monitor.py --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 import argparse
 import json

--- a/test_offline_retry.py
+++ b/test_offline_retry.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Tests for cloud recovery after offline fallback (issue #23).
+
+Verifies:
+1. A transient cloud login failure sets the "fell back to offline" flag.
+2. _try_cloud_recovery() is a no-op until cloud_retry_interval has elapsed.
+3. On a successful retry, offline_mode clears and MQTT is reconnected.
+4. A user-forced --offline run never triggers cloud recovery.
+"""
+
+import base64
+import os
+import sys
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Mock paho.mqtt before importing pecron_monitor (same trick as test_local_fix.py)
+sys.modules['paho'] = MagicMock()
+sys.modules['paho.mqtt'] = MagicMock()
+sys.modules['paho.mqtt.client'] = MagicMock()
+
+from monitor import PecronMonitor  # noqa: E402
+
+FAKE_AUTH_KEY = base64.b64encode(b"0123456789abcdef").decode()
+
+
+def make_config():
+    return {
+        "email": "test@test.com",
+        "password": "test",
+        "region": "na",
+        "devices": [{
+            "product_key": "p11u2b",
+            "device_key": "682499E40D61",
+            "name": "E1500LFP",
+            "lan_ip": "192.168.68.51",
+            "auth_key": FAKE_AUTH_KEY,
+        }],
+        "poll_interval": 60,
+        "cloud_retry_interval": 300,
+    }
+
+
+class TestCloudRecovery(unittest.TestCase):
+
+    def test_transient_failure_sets_fallback_flag(self):
+        """A DNS-style cloud login failure leaves the monitor in a retry-eligible state."""
+        config = make_config()
+        monitor = PecronMonitor(config)
+        # Even though devices have lan_ip+auth_key (offline-capable), we expect the
+        # fallback path to run because login() raises, not the forced-offline path.
+        with patch("monitor.login", side_effect=OSError("Temporary failure in name resolution")):
+            monitor.authenticate(force_offline=False)
+        self.assertTrue(monitor.offline_mode, "Should fall back to offline on login failure")
+        self.assertTrue(monitor._fell_back_to_offline, "Should flag the fallback as unplanned")
+        self.assertGreater(monitor._last_cloud_retry_at, 0,
+                           "Fallback should stamp _last_cloud_retry_at so the first retry waits")
+
+    def test_forced_offline_never_retries(self):
+        """`--offline` runs are an explicit user choice and must not retry cloud."""
+        config = make_config()
+        monitor = PecronMonitor(config)
+        monitor.authenticate(force_offline=True)
+        self.assertTrue(monitor.offline_mode)
+        self.assertFalse(monitor._fell_back_to_offline,
+                         "Forced offline must not be flagged as a transient fallback")
+        # Even without the interval guard, recovery should bail out immediately.
+        self.assertFalse(monitor._try_cloud_recovery(),
+                         "Forced offline mode should never attempt cloud recovery")
+
+    def test_recovery_respects_retry_interval(self):
+        """Between retries the monitor stays silent; one attempt per interval only."""
+        config = make_config()
+        monitor = PecronMonitor(config)
+        monitor.offline_mode = True
+        monitor._fell_back_to_offline = True
+        monitor._last_cloud_retry_at = time.time()  # just attempted
+        with patch("monitor.login") as mock_login:
+            self.assertFalse(monitor._try_cloud_recovery(),
+                             "Should not retry inside the cooldown window")
+            mock_login.assert_not_called()
+
+    def test_successful_recovery_exits_offline_mode(self):
+        """On retry success the monitor rejoins cloud and clears the flags."""
+        config = make_config()
+        monitor = PecronMonitor(config)
+        monitor.offline_mode = True
+        monitor._fell_back_to_offline = True
+        monitor._last_cloud_retry_at = 0  # cooldown already passed
+        monitor.skip_local_setup = True   # keep the test focused on cloud-side state
+        monitor.connect_mqtt = MagicMock()
+
+        fake_token = {"token": "t", "uid": "U1", "expires_at": time.time() + 3600}
+        with patch("monitor.login", return_value=fake_token), \
+             patch("monitor.resolve_devices", return_value=[{
+                 "product_key": "p11u2b",
+                 "device_key": "682499E40D61",
+                 "device_name": "E1500LFP",
+                 "product_name": "E1500LFP",
+                 "controls": {},
+             }]):
+            recovered = monitor._try_cloud_recovery()
+
+        self.assertTrue(recovered, "Retry should report success")
+        self.assertFalse(monitor.offline_mode, "offline_mode should clear on recovery")
+        self.assertFalse(monitor._fell_back_to_offline, "fallback flag should clear on recovery")
+        self.assertEqual(monitor.token_data, fake_token)
+        monitor.connect_mqtt.assert_called_once()
+
+    def test_failed_recovery_stays_offline_and_defers(self):
+        """A continuing network failure leaves offline_mode intact and records the attempt."""
+        config = make_config()
+        monitor = PecronMonitor(config)
+        monitor.offline_mode = True
+        monitor._fell_back_to_offline = True
+        monitor._last_cloud_retry_at = 0
+
+        with patch("monitor.login", side_effect=OSError("Temporary failure in name resolution")):
+            recovered = monitor._try_cloud_recovery()
+
+        self.assertFalse(recovered)
+        self.assertTrue(monitor.offline_mode)
+        self.assertTrue(monitor._fell_back_to_offline)
+        self.assertGreater(monitor._last_cloud_retry_at, 0,
+                           "Failed attempt still arms the cooldown so we don't hammer the cloud")
+
+    def test_token_refresh_remains_disabled_in_offline_mode(self):
+        """Regression: offline-mode token refresh short-circuit must still hold."""
+        config = make_config()
+        monitor = PecronMonitor(config)
+        monitor.offline_mode = True
+        monitor._fell_back_to_offline = True
+        monitor.token_data = None
+        self.assertFalse(monitor._token_needs_refresh(),
+                         "Offline mode should never try to refresh the cloud token")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #23.

## Summary
- Fixes the "fail once → stuck forever" bug pair: cloud login failure leaving the monitor permanently in offline mode, and Home Assistant MQTT bridge giving up on its initial connect.
- Version bumped to 0.7.1.

## What changed

**Cloud recovery (`monitor.py`).** A new `_fell_back_to_offline` flag distinguishes an unplanned fallback (transient DNS / ISP / router-reboot failure during cloud login) from a user-requested `--offline` run. The main loop calls `_try_cloud_recovery()` every `cloud_retry_interval` seconds (default 300s) while in a fallback state; on success it rejoins cloud MQTT and refreshes local transports. Forced-offline runs are explicitly excluded from retries.

**HA bridge retry (`ha_bridge.py`).** `connect()` is split into `_connect_attempt()` + `try_reconnect()`. The monitor's main loop drives `try_reconnect()` every `homeassistant.retry_interval` seconds (default 60s) when the initial connect failed. paho-mqtt's built-in `reconnect_delay_set` + `loop_start` continues to handle drops after a successful initial session — we only close the startup gap.

Two new optional config knobs (safe defaults): `cloud_retry_interval` at top level, `homeassistant.retry_interval` under `homeassistant:`.

## Test plan
- [x] Unit tests added in `test_offline_retry.py` (6 tests, all passing): fallback flag set on transient failure, forced-offline never retries, cooldown respected, successful recovery clears flags + reconnects MQTT, failed recovery stays offline + defers, regression on offline-mode token-refresh short-circuit.
- [x] Integration tested against real hardware (E1500LFP + E3800LFP on Stills). Simulated the exact DNS error from #23 (`OSError("Temporary failure in name resolution")`) → fallback fired with `offline_mode=True`, `_fell_back_to_offline=True`, both devices loaded from config. After cooldown, `_try_cloud_recovery()` called real Pecron cloud, got valid token, resolved both devices, transitioned to online state in 2.3s.
- [x] Production service on Stills restarted on this branch and continues to flow telemetry via local TCP + cloud MQTT with no regression.
- [x] Existing `test_local_fix.py` regression on `_token_needs_refresh()` in offline mode still passes (re-verified in new test file as well).

🤖 Generated with [Claude Code](https://claude.com/claude-code)