### PR TITLE
fix: E3600 battery capacity, skip no-op high_freq, rest_only refetch (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to pecron-monitor are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [0.7.2] — 2026-04-19
+
+Targeted E3600LFP follow-ups from #14, informed by detailed testing and debugging from @brucehoult and @derekclawson.
+
+### Fixed
+- **E3600 / E3600LFP battery capacity was wrong** (#14). v0.7.0 set `BATTERY_CAPACITY_WH["E3600LFP"] = 3600`, but "3600" in the model name refers to the inverter wattage — the actual LiFePO4 pack is **3072Wh** (same as the F3000LFP). Caught by @brucehoult. All displays, alerts, and time-to-empty estimates now use the correct capacity.
+- **`--rest-only` stopped refreshing data after the first poll** (#14). In rest-only mode, `_request_status()` guarded the REST fetch with `if dk not in self.latest_data:` — so after cycle 1 the device appeared frozen. Now re-fetches every poll when `rest_only=True`. Fix from @brucehoult.
+- **`--status` and `--raw` left the device in high-freq mode on exit**. Both one-shot commands now call `_disable_high_freq_reporting()` before shutting down MQTT, preventing a single CLI invocation from leaving the device burning cloud quota indefinitely.
+
+### Changed
+- **Skip `high_frequency_reporting` sends on models where it's a known no-op** (#14). `@brucehoult` verified on E3600LFP that the setting has no observable effect across multiple cadences — telemetry arrives every ~20 minutes regardless. New `MODEL_BEHAVIOR` map in `constants.py` lets us mark a model's `high_freq_effective=False`; the enable/disable helpers and `--status` path respect it. E3600 and E3600LFP are now skipped. E3800LFP and E1500LFP behavior is unchanged.
+
+### Docs
+- `docs/known-pecron-api-quirks.md` updated with three new entries:
+  - E3600LFP ignores `high_frequency_reporting` (credit: @brucehoult).
+  - Pecron cloud returns `code 4026 — Insufficient resources` daily at ~23:00 UTC until 00:00 UTC reset (credit: @brucehoult, reproducible with the service stopped and the app closed).
+  - E3600LFP battery capacity is 3072Wh, not 3600Wh.
+
 ## [0.7.1] — 2026-04-19
 
 ### Fixed

--- a/constants.py
+++ b/constants.py
@@ -60,10 +60,27 @@ BATTERY_CAPACITY_WH = {
     "E2000LFP": "1920",
     "E2400LFP": "2048",
     "F3000LFP": "3072",
-    "E3600": "3600",
-    "E3600LFP": "3600",
+    # E3600 / E3600LFP: the "3600" in the name is the inverter wattage; actual
+    # LiFePO4 pack is 3072Wh (same as the F3000LFP). Caught by @brucehoult in
+    # issue #14 after v0.7.0 shipped the wrong value.
+    "E3600": "3072",
+    "E3600LFP": "3072",
     "E3800LFP": "3840",
     "F5000LFP": "5120",
+}
+
+# Per-model behavior flags. Used to skip operations that are known to be
+# no-ops or harmful on specific firmware. Unlisted models default to the
+# permissive baseline ({"high_freq_effective": True}).
+#
+# high_freq_effective=False: sending `high_frequency_reporting=3` to this
+# model has no observable effect on MQTT cadence. @brucehoult verified this
+# on E3600LFP (issue #14) across many cadences — data still arrives every
+# ~20 minutes regardless. Skipping the send saves cloud requests and reduces
+# noise when the device is running near Pecron's quota ceiling.
+MODEL_BEHAVIOR: dict[str, dict[str, bool]] = {
+    "E3600": {"high_freq_effective": False},
+    "E3600LFP": {"high_freq_effective": False},
 }
 
 # ---------------------------------------------------------------------------

--- a/docs/known-pecron-api-quirks.md
+++ b/docs/known-pecron-api-quirks.md
@@ -12,6 +12,33 @@ The Pecron cloud API returns the same integer for both `remain_time` ("dischargi
 
 This is a firmware/API bug, not something any client library can fix. Originally reverse-engineered and published by jsight; we're citing their evidence directly.
 
+## `high_frequency_reporting` is ignored by E3600LFP firmware
+
+**First documented by:** [@brucehoult in pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
+**Affects:** Cloud MQTT on E3600LFP (E3800LFP still honors the setting)
+
+TSL property `high_frequency_reporting` (id=100, ENUM) is meant to make the device push telemetry every few seconds instead of the normal cadence. It works on E3800LFP, E1500LFP, and most other Pecron models — but on the E3600LFP the setting has no observable effect. @brucehoult verified this across multiple test cadences: sending `=3` every 20 seconds, every 5 minutes, or never at all, all produce identical behavior — one telemetry packet per value-type every ~20 minutes.
+
+pecron-monitor skips the send entirely for E3600/E3600LFP (see `MODEL_BEHAVIOR` in `constants.py`) to avoid wasting cloud requests. The only observed way to force faster telemetry on an E3600 is to leave the official Pecron mobile app open on the device's status screen — but that causes the "Insufficient resources" quota exhaustion documented in the next entry, so it's not a real workaround.
+
+## Pecron cloud `code 4026 — Insufficient resources` around 23:00 UTC daily
+
+**First documented by:** [@brucehoult in pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
+**Affects:** Cloud MQTT and REST on E3600LFP (possibly others — unconfirmed for now)
+
+Starting near 23:00-23:15 UTC, the Pecron cloud begins returning `type=BUSI-ERROR, code=4026, msg='Insufficient resources in the manufacturer's account. Please contact the device manufacturer.'` for control writes. Telemetry packets stop arriving. Service resumes like clockwork at 00:00 UTC — consistent with a daily quota reset on Pecron's side.
+
+@brucehoult reproduced this for four consecutive days after upgrading to v0.7.0, and importantly **it happens with pecron-monitor stopped and the Pecron app not open** — so the quota is attached to the manufacturer's account, not our request volume. Nothing pecron-monitor can do about it besides waiting for 00:00 UTC.
+
+If this affects your usage pattern, the 23:00 UTC window is a poor time to rely on automations that send control commands. The monitor continues running and will resume normal operation once the Pecron cloud clears its quota.
+
+## E3600LFP battery capacity is 3072Wh, not 3600Wh
+
+**First documented by:** [@brucehoult in pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
+**Affects:** Any calculation using `BATTERY_CAPACITY_WH`
+
+The "3600" in E3600LFP is the inverter wattage, not the battery capacity. The actual LiFePO4 pack is 3072Wh — identical to the F3000LFP. Easy to get wrong because every other model in the lineup names itself after the pack size (E1500LFP = 1536Wh, E3800LFP = 3840Wh, etc.). v0.7.0 shipped the wrong value; v0.7.2 corrects it.
+
 ## E3600LFP / E3800LFP telemetry arrives in alternating MQTT packets
 
 **First documented here:** [pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)

--- a/monitor.py
+++ b/monitor.py
@@ -19,7 +19,7 @@ except ImportError:
 
 from helpers import _truthy, _get_kv, _get_kv_single
 from typing import Any, Optional
-from constants import DEVICE_STATUS_LABELS, REGIONS, DEFAULT_CONTROLS, SENSOR_FIELDS, BATTERY_CAPACITY_WH
+from constants import DEVICE_STATUS_LABELS, REGIONS, DEFAULT_CONTROLS, SENSOR_FIELDS, BATTERY_CAPACITY_WH, MODEL_BEHAVIOR
 from cloud_api import (
     login, resolve_devices, get_device_properties_rest, set_device_property_rest
 )
@@ -1158,10 +1158,14 @@ class PecronMonitor:
                 log.debug("Published TTLV read to %s (rc=%s, mid=%s)",
                           topic, result.rc, result.mid)
 
-            # If we haven't received MQTT data for this device yet, try REST API
-            if dk not in self.latest_data:
+            # If we haven't received MQTT data for this device yet, try REST API.
+            # In rest_only mode there is no MQTT or local TCP, so we must re-fetch
+            # every poll rather than only on the first time (fix from @brucehoult
+            # in issue #14 — otherwise --rest-only stops updating after cycle 1).
+            if self.rest_only or dk not in self.latest_data:
                 if self.token_data:  # Only available if not in offline mode
-                    log.debug("No MQTT data for %s yet, trying REST API fallback...", dk)
+                    log.debug("Fetching status via REST API for %s (rest_only=%s, cached=%s)...",
+                              dk, self.rest_only, dk in self.latest_data)
                     kv = get_device_properties_rest(
                         self.token_data["token"], self.region,
                         device["product_key"], dk
@@ -1323,25 +1327,39 @@ class PecronMonitor:
             if self.ha_bridge:
                 self.ha_bridge.disconnect()
 
+    @staticmethod
+    def _high_freq_effective(device: dict) -> bool:
+        """Return False for models where high_frequency_reporting is a known no-op
+        (issue #14 — E3600LFP ignores the setting; don't waste cloud requests)."""
+        name = device.get("device_name") or device.get("product_name") or ""
+        return MODEL_BEHAVIOR.get(name, {}).get("high_freq_effective", True)
+
     def _enable_high_freq_reporting(self, stagger: float = 0):
         """Enable high-frequency MQTT reporting on all devices for fast cache warm-up.
-        
+
         Args:
             stagger: Seconds to wait between devices (helps cloud process multi-device requests)
         """
-        for i, d in enumerate(self.devices):
+        effective = [d for d in self.devices if self._high_freq_effective(d)]
+        skipped = [d for d in self.devices if not self._high_freq_effective(d)]
+        for d in skipped:
+            log.debug("Skipping high-freq enable for %s — ineffective on this model (issue #14)",
+                      d.get("device_name") or d["device_key"])
+        for i, d in enumerate(effective):
             dk = d["device_key"]
             try:
                 self.send_control(dk, "high_frequency_reporting", 3)
                 log.info("Enabled high-freq reporting for %s", dk)
             except Exception as e:
                 log.debug("Could not enable high-freq for %s: %s", dk, e)
-            if stagger > 0 and i < len(self.devices) - 1:
+            if stagger > 0 and i < len(effective) - 1:
                 time.sleep(stagger)
 
     def _disable_high_freq_reporting(self):
         """Disable high-frequency reporting after warm-up period."""
         for d in self.devices:
+            if not self._high_freq_effective(d):
+                continue  # never enabled → nothing to disable
             dk = d["device_key"]
             try:
                 self.send_control(dk, "high_frequency_reporting", 0)
@@ -1396,17 +1414,10 @@ class PecronMonitor:
             self.connect_mqtt()
             time.sleep(3)
             # Enable high-freq reporting for devices that need it (E3600/E3800)
-            # Stagger requests to avoid cloud throttling for multi-device setups
+            # Stagger requests to avoid cloud throttling for multi-device setups.
+            # Use the shared helper so the per-model skip (issue #14) applies here too.
             if self.mqtt_client:
-                for i, d in enumerate(self.devices):
-                    dk = d["device_key"]
-                    try:
-                        self.send_control(dk, "high_frequency_reporting", 3)
-                        log.info("Enabled high-freq reporting for %s", dk)
-                    except Exception as e:
-                        log.debug("Could not enable high-freq for %s: %s", dk, e)
-                    if i < len(self.devices) - 1:
-                        time.sleep(1)  # Stagger between devices
+                self._enable_high_freq_reporting(stagger=1)
                 time.sleep(2)  # Give devices time to switch modes
         self._request_status()
         
@@ -1582,7 +1593,11 @@ class PecronMonitor:
         if not self.latest_data:
             print("No data received — device may be offline.")
 
+        # Leave the device in its normal cadence — don't strand it in high-freq
+        # mode after a one-shot --status run (would burn cloud quota if another
+        # process checks status often). Cheap no-op for skipped models.
         if self.mqtt_client:
+            self._disable_high_freq_reporting()
             self.mqtt_client.loop_stop()
             self.mqtt_client.disconnect()
 

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     python pecron_monitor.py --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 import argparse
 import json
@@ -183,7 +183,9 @@ def main():
             print(json.dumps({dk: kv}, indent=2, default=str))
         if not monitor.latest_data:
             print("No data received — device may be offline.")
+        # Don't leave the device stranded in high-freq mode after --raw exits.
         if monitor.mqtt_client:
+            monitor._disable_high_freq_reporting()
             monitor.mqtt_client.loop_stop()
             monitor.mqtt_client.disconnect()
         return

--- a/test_model_behavior.py
+++ b/test_model_behavior.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tests for per-model behavior flags (issue #14).
+
+Verifies that `high_frequency_reporting` is skipped for models where it's a
+known no-op (E3600LFP) and still sent for models where it's effective.
+"""
+
+import base64
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+sys.modules['paho'] = MagicMock()
+sys.modules['paho.mqtt'] = MagicMock()
+sys.modules['paho.mqtt.client'] = MagicMock()
+
+from constants import MODEL_BEHAVIOR  # noqa: E402
+from monitor import PecronMonitor  # noqa: E402
+
+FAKE_AUTH = base64.b64encode(b"0123456789abcdef").decode()
+
+
+def make_monitor(device_names):
+    config = {
+        "email": "x", "password": "x", "region": "na",
+        "devices": [{"product_key": "pk", "device_key": f"dk{i}", "name": n,
+                     "lan_ip": f"10.0.0.{i+1}", "auth_key": FAKE_AUTH}
+                    for i, n in enumerate(device_names)],
+    }
+    m = PecronMonitor(config)
+    m.devices = [{"product_key": "pk", "device_key": f"dk{i}", "device_name": n, "product_name": n,
+                  "controls": {}} for i, n in enumerate(device_names)]
+    m.send_control = MagicMock()  # don't actually try to send anything
+    return m
+
+
+class TestModelBehavior(unittest.TestCase):
+
+    def test_e3600_flag_set(self):
+        self.assertFalse(MODEL_BEHAVIOR["E3600LFP"]["high_freq_effective"])
+        self.assertFalse(MODEL_BEHAVIOR["E3600"]["high_freq_effective"])
+
+    def test_enable_skips_e3600(self):
+        m = make_monitor(["E3600LFP"])
+        m._enable_high_freq_reporting()
+        m.send_control.assert_not_called()
+
+    def test_enable_sends_for_e3800(self):
+        m = make_monitor(["E3800LFP"])
+        m._enable_high_freq_reporting()
+        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 3)
+
+    def test_mixed_fleet_sends_only_for_effective_models(self):
+        """A mixed config should send for E3800LFP and skip E3600LFP."""
+        m = make_monitor(["E3800LFP", "E3600LFP", "E1500LFP"])
+        m._enable_high_freq_reporting()
+        sent_dks = [call.args[0] for call in m.send_control.call_args_list]
+        self.assertEqual(set(sent_dks), {"dk0", "dk2"},
+                         f"Expected E3800LFP + E1500LFP only, got {sent_dks}")
+
+    def test_disable_skips_e3600(self):
+        m = make_monitor(["E3600LFP"])
+        m._disable_high_freq_reporting()
+        m.send_control.assert_not_called()
+
+    def test_disable_sends_for_e3800(self):
+        m = make_monitor(["E3800LFP"])
+        m._disable_high_freq_reporting()
+        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 0)
+
+    def test_unknown_model_defaults_to_effective(self):
+        """Baseline (unlisted models) keeps current behavior: send the setting."""
+        m = make_monitor(["SomeNewModel"])
+        m._enable_high_freq_reporting()
+        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 3)
+
+
+class TestE3600Capacity(unittest.TestCase):
+    """Regression: v0.7.0 incorrectly set E3600LFP to 3600Wh. Should be 3072Wh."""
+
+    def test_e3600_is_3072(self):
+        from constants import BATTERY_CAPACITY_WH
+        self.assertEqual(BATTERY_CAPACITY_WH["E3600LFP"], "3072")
+        self.assertEqual(BATTERY_CAPACITY_WH["E3600"], "3072")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Targeted follow-ups from [#14](https://github.com/attractify-logan/pecron-monitor/issues/14) after the extensive reproduction testing and debugging work from @brucehoult and @derekclawson. v0.7.2.

## Summary
- **E3600 / E3600LFP battery capacity was wrong** — v0.7.0 set 3600Wh but the actual pack is 3072Wh. The "3600" in the model name is the inverter wattage. Caught and reported by @brucehoult.
- **`high_frequency_reporting` is now skipped on E3600LFP** — @brucehoult verified (across 20s / 5min / never cadences) that the setting has no observable effect on this model, so sending it just wastes cloud requests. New `MODEL_BEHAVIOR` map gates the send per-model. E3800LFP, E1500LFP, F3000LFP etc. unchanged.
- **`--rest-only` stopped refreshing after cycle 1** — REST fetch was guarded by `if dk not in self.latest_data:`, which in `rest_only` mode (no MQTT, no local TCP) meant one successful fetch froze the display forever. Fix from @brucehoult.
- **`--status` and `--raw` now disable high-freq before exiting** — a one-shot command should never leave the device stranded in high-freq mode between invocations.

## Not in scope (flagged for follow-up)
- **Pecron cloud `code 4026` "Insufficient resources" daily at ~23:00 UTC.** @brucehoult documented this reproducibly across 4+ consecutive days, and crucially reproduced it **with pecron-monitor stopped and the Pecron app closed**. The quota appears to be at the Pecron manufacturer-account level — nothing this project can fix. Documented in `docs/known-pecron-api-quirks.md` with credit to Bruce so future users understand what's happening.
- **E3600LFP telemetry only arrives every ~20 min via cloud MQTT.** @brucehoult's testing suggests this is a device firmware behavior, not a request-pattern issue. No reproducible mechanism exists to force faster updates short of leaving the mobile app open on the device status screen (which then triggers the 23:00 UTC quota window). Same quirks doc.
- **@derekclawson's recent `UserDomain does not exist` login error** — appears to be a separate NA-region login regression and needs its own investigation.

## Test plan
- [x] 8 new unit tests in `test_model_behavior.py` covering: the flag map itself, enable-skips-E3600, enable-sends-for-E3800, mixed-fleet correctness (E3800+E3600+E1500 → only E3800+E1500 get the send), disable-skips-E3600, disable-sends-for-E3800, unknown-model default (permissive), and the E3600LFP=3072Wh capacity regression. All pass.
- [x] `test_offline_retry.py` (from #26) still passes — no regression on cloud recovery logic.
- [x] Deployed `fix/e3600-polish-v0.7.2` to Stills (E3800LFP + E1500LFP + WB12200). Service respawns clean on v0.7.2, all three devices go through enable→warmup→disable correctly (68s), telemetry flowing via local TCP + cloud MQTT as before. No regression on effective models.
- [x] `rest_only` behavior verified by code review (full refetch every poll when the flag is set; cache-first behavior preserved for the normal cloud path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)