### PR TITLE
release: v0.8.0 consolidating today's retry + E3600 work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,34 +4,38 @@ All notable changes to pecron-monitor are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
-## [0.7.2] — 2026-04-19
+## [0.8.0] - 2026-04-19
+
+Consolidates the 0.7.1 and 0.7.2 reliability work into a single release so users pinning versions see a clear signal for the new retry loops, the new config knobs, and the new per-model behavior system. No code differences from 0.7.2 itself.
+
+## [0.7.2] - 2026-04-19
 
 Targeted E3600LFP follow-ups from #14, informed by detailed testing and debugging from @brucehoult and @derekclawson.
 
 ### Fixed
-- **E3600 / E3600LFP battery capacity was wrong** (#14). v0.7.0 set `BATTERY_CAPACITY_WH["E3600LFP"] = 3600`, but "3600" in the model name refers to the inverter wattage — the actual LiFePO4 pack is **3072Wh** (same as the F3000LFP). Caught by @brucehoult. All displays, alerts, and time-to-empty estimates now use the correct capacity.
-- **`--rest-only` stopped refreshing data after the first poll** (#14). In rest-only mode, `_request_status()` guarded the REST fetch with `if dk not in self.latest_data:` — so after cycle 1 the device appeared frozen. Now re-fetches every poll when `rest_only=True`. Fix from @brucehoult.
+- **E3600 / E3600LFP battery capacity was wrong** (#14). v0.7.0 set `BATTERY_CAPACITY_WH["E3600LFP"] = 3600`, but "3600" in the model name refers to the inverter wattage, not the pack. Actual LiFePO4 pack is **3072Wh** (same as the F3000LFP). Caught by @brucehoult. All displays, alerts, and time-to-empty estimates now use the correct capacity.
+- **`--rest-only` stopped refreshing data after the first poll** (#14). In rest-only mode, `_request_status()` guarded the REST fetch with `if dk not in self.latest_data:`, so after cycle 1 the device appeared frozen. Now re-fetches every poll when `rest_only=True`. Fix from @brucehoult.
 - **`--status` and `--raw` left the device in high-freq mode on exit**. Both one-shot commands now call `_disable_high_freq_reporting()` before shutting down MQTT, preventing a single CLI invocation from leaving the device burning cloud quota indefinitely.
 
 ### Changed
-- **Skip `high_frequency_reporting` sends on models where it's a known no-op** (#14). `@brucehoult` verified on E3600LFP that the setting has no observable effect across multiple cadences — telemetry arrives every ~20 minutes regardless. New `MODEL_BEHAVIOR` map in `constants.py` lets us mark a model's `high_freq_effective=False`; the enable/disable helpers and `--status` path respect it. E3600 and E3600LFP are now skipped. E3800LFP and E1500LFP behavior is unchanged.
+- **Skip `high_frequency_reporting` sends on models where it's a known no-op** (#14). `@brucehoult` verified on E3600LFP that the setting has no observable effect across multiple cadences; telemetry arrives every ~20 minutes regardless. New `MODEL_BEHAVIOR` map in `constants.py` lets us mark a model's `high_freq_effective=False`; the enable/disable helpers and `--status` path respect it. E3600 and E3600LFP are now skipped. E3800LFP and E1500LFP behavior is unchanged.
 
 ### Docs
 - `docs/known-pecron-api-quirks.md` updated with three new entries:
   - E3600LFP ignores `high_frequency_reporting` (credit: @brucehoult).
-  - Pecron cloud returns `code 4026 — Insufficient resources` daily at ~23:00 UTC until 00:00 UTC reset (credit: @brucehoult, reproducible with the service stopped and the app closed).
+  - Pecron cloud returns `code 4026 Insufficient resources` daily at ~23:00 UTC until 00:00 UTC reset (credit: @brucehoult, reproducible with the service stopped and the app closed).
   - E3600LFP battery capacity is 3072Wh, not 3600Wh.
 
-## [0.7.1] — 2026-04-19
+## [0.7.1] - 2026-04-19
 
 ### Fixed
-- **Cloud login failure no longer strands the monitor in offline mode forever** (#23). When a token refresh hits a transient network error (DNS outage, router reboot, ISP blip, etc.), the monitor falls back to offline mode as before — but now retries cloud re-login every `cloud_retry_interval` seconds (default: 300s). On a successful retry, MQTT is reconnected and local transports are refreshed automatically. User-requested `--offline` runs are never retried.
+- **Cloud login failure no longer strands the monitor in offline mode forever** (#23). When a token refresh hits a transient network error (DNS outage, router reboot, ISP blip, etc.), the monitor falls back to offline mode as before, then retries cloud re-login every `cloud_retry_interval` seconds (default: 300s). On a successful retry, MQTT is reconnected and local transports are refreshed automatically. User-requested `--offline` runs are never retried.
 - **Home Assistant MQTT bridge now retries a failed initial connection** (#23 follow-up). If the local MQTT broker is down when the monitor starts, the bridge attempts to reconnect every `homeassistant.retry_interval` seconds (default: 60s) instead of giving up permanently. `paho-mqtt`'s built-in auto-reconnect already handles drops after an established connection; this fix closes the startup gap.
 
 ### Added
 - Two config knobs (both optional, safe defaults):
-  - `cloud_retry_interval` at the top level — seconds between cloud recovery attempts.
-  - `homeassistant.retry_interval` — seconds between HA broker reconnect attempts.
+  - `cloud_retry_interval` at the top level: seconds between cloud recovery attempts.
+  - `homeassistant.retry_interval`: seconds between HA broker reconnect attempts.
 
 ## [0.7.0] — 2026-04-04
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.7.0** · [Changelog](CHANGELOG.md)
+**v0.8.0** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 
@@ -265,11 +265,11 @@ Don't see yours? It probably still works — `--setup` checks all known product 
 
 ## Related Projects
 
-- [**jsight/unofficial-pecron-api**](https://github.com/jsight/unofficial-pecron-api) — a clean Python library for the Pecron cloud REST API, published to PyPI (`pip install unofficial-pecron-api`). If you only need cloud access from Python (no local TCP, BLE, MQTT streaming, or Home Assistant integration) and want a well-typed SDK with dataclass models and a focused CLI, it's a great choice. Separate reverse-engineering effort — credit for a few of the Pecron API quirks documented [here](docs/known-pecron-api-quirks.md) belongs to that project.
+- [**jsight/unofficial-pecron-api**](https://github.com/jsight/unofficial-pecron-api): a clean Python library for the Pecron cloud REST API, published to PyPI (`pip install unofficial-pecron-api`). If you only need cloud access from Python (no local TCP, BLE, MQTT streaming, or Home Assistant integration) and want a well-typed SDK with dataclass models and a focused CLI, it's a great choice. Separate reverse-engineering effort. Credit for a few of the Pecron API quirks documented [here](docs/known-pecron-api-quirks.md) belongs to that project.
 
 ## Known Pecron API Quirks
 
-Bugs and oddities in Pecron's cloud API / device firmware that affect integrations — see [docs/known-pecron-api-quirks.md](docs/known-pecron-api-quirks.md).
+Bugs and oddities in Pecron's cloud API / device firmware that affect integrations. See [docs/known-pecron-api-quirks.md](docs/known-pecron-api-quirks.md).
 
 ## Contributing
 

--- a/constants.py
+++ b/constants.py
@@ -61,7 +61,7 @@ BATTERY_CAPACITY_WH = {
     "E2400LFP": "2048",
     "F3000LFP": "3072",
     # E3600 / E3600LFP: the "3600" in the name is the inverter wattage; actual
-    # LiFePO4 pack is 3072Wh (same as the F3000LFP). Caught by @brucehoult in
+    # LiFePO4 pack is 3072Wh, same as the F3000LFP. Caught by @brucehoult in
     # issue #14 after v0.7.0 shipped the wrong value.
     "E3600": "3072",
     "E3600LFP": "3072",
@@ -75,7 +75,7 @@ BATTERY_CAPACITY_WH = {
 #
 # high_freq_effective=False: sending `high_frequency_reporting=3` to this
 # model has no observable effect on MQTT cadence. @brucehoult verified this
-# on E3600LFP (issue #14) across many cadences — data still arrives every
+# on E3600LFP (issue #14) across many cadences. Data still arrives every
 # ~20 minutes regardless. Skipping the send saves cloud requests and reduces
 # noise when the device is running near Pecron's quota ceiling.
 MODEL_BEHAVIOR: dict[str, dict[str, bool]] = {

--- a/docs/known-pecron-api-quirks.md
+++ b/docs/known-pecron-api-quirks.md
@@ -1,6 +1,6 @@
 # Known Pecron API Quirks
 
-A running log of bugs, inconsistencies, and undocumented behavior observed in Pecron's cloud API and device firmware. Each entry names the first project to document the behavior so credit stays with the original discoverer. If you've hit something new, PRs welcome — please cite the bug report that surfaced it.
+A running log of bugs, inconsistencies, and undocumented behavior observed in Pecron's cloud API and device firmware. Each entry names the first project to document the behavior so credit stays with the original discoverer. If you've hit something new, PRs welcome. Please cite the bug report that surfaced it.
 
 ## `remain_time` and `remain_charging_time` report identical values
 
@@ -8,7 +8,7 @@ A running log of bugs, inconsistencies, and undocumented behavior observed in Pe
 **Confirmed on:** E300LFP, E1500LFP, E3800LFP
 **Affects:** REST API, cloud MQTT
 
-The Pecron cloud API returns the same integer for both `remain_time` ("discharging time") and `remain_charging_time` ("full charging time"), regardless of whether the device is charging or discharging. Only one of the two values is meaningful at any given moment — the monitor infers which by looking at whether net power is flowing in or out.
+The Pecron cloud API returns the same integer for both `remain_time` ("discharging time") and `remain_charging_time` ("full charging time"), regardless of whether the device is charging or discharging. Only one of the two values is meaningful at any given moment; the monitor infers which by looking at whether net power is flowing in or out.
 
 This is a firmware/API bug, not something any client library can fix. Originally reverse-engineered and published by jsight; we're citing their evidence directly.
 
@@ -17,18 +17,18 @@ This is a firmware/API bug, not something any client library can fix. Originally
 **First documented by:** [@brucehoult in pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
 **Affects:** Cloud MQTT on E3600LFP (E3800LFP still honors the setting)
 
-TSL property `high_frequency_reporting` (id=100, ENUM) is meant to make the device push telemetry every few seconds instead of the normal cadence. It works on E3800LFP, E1500LFP, and most other Pecron models — but on the E3600LFP the setting has no observable effect. @brucehoult verified this across multiple test cadences: sending `=3` every 20 seconds, every 5 minutes, or never at all, all produce identical behavior — one telemetry packet per value-type every ~20 minutes.
+TSL property `high_frequency_reporting` (id=100, ENUM) is meant to make the device push telemetry every few seconds instead of the normal cadence. It works on E3800LFP, E1500LFP, and most other Pecron models, but on the E3600LFP the setting has no observable effect. @brucehoult verified this across multiple test cadences: sending `=3` every 20 seconds, every 5 minutes, or never at all all produce identical behavior, one telemetry packet per value-type every ~20 minutes.
 
-pecron-monitor skips the send entirely for E3600/E3600LFP (see `MODEL_BEHAVIOR` in `constants.py`) to avoid wasting cloud requests. The only observed way to force faster telemetry on an E3600 is to leave the official Pecron mobile app open on the device's status screen — but that causes the "Insufficient resources" quota exhaustion documented in the next entry, so it's not a real workaround.
+pecron-monitor skips the send entirely for E3600/E3600LFP (see `MODEL_BEHAVIOR` in `constants.py`) to avoid wasting cloud requests. The only observed way to force faster telemetry on an E3600 is to leave the official Pecron mobile app open on the device's status screen, but that causes the "Insufficient resources" quota exhaustion documented in the next entry, so it's not a real workaround.
 
-## Pecron cloud `code 4026 — Insufficient resources` around 23:00 UTC daily
+## Pecron cloud `code 4026 Insufficient resources` around 23:00 UTC daily
 
 **First documented by:** [@brucehoult in pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
-**Affects:** Cloud MQTT and REST on E3600LFP (possibly others — unconfirmed for now)
+**Affects:** Cloud MQTT and REST on E3600LFP (possibly others, unconfirmed for now)
 
-Starting near 23:00-23:15 UTC, the Pecron cloud begins returning `type=BUSI-ERROR, code=4026, msg='Insufficient resources in the manufacturer's account. Please contact the device manufacturer.'` for control writes. Telemetry packets stop arriving. Service resumes like clockwork at 00:00 UTC — consistent with a daily quota reset on Pecron's side.
+Starting near 23:00-23:15 UTC, the Pecron cloud begins returning `type=BUSI-ERROR, code=4026, msg='Insufficient resources in the manufacturer's account. Please contact the device manufacturer.'` for control writes. Telemetry packets stop arriving. Service resumes like clockwork at 00:00 UTC, consistent with a daily quota reset on Pecron's side.
 
-@brucehoult reproduced this for four consecutive days after upgrading to v0.7.0, and importantly **it happens with pecron-monitor stopped and the Pecron app not open** — so the quota is attached to the manufacturer's account, not our request volume. Nothing pecron-monitor can do about it besides waiting for 00:00 UTC.
+@brucehoult reproduced this for four consecutive days after upgrading to v0.7.0, and importantly **it happens with pecron-monitor stopped and the Pecron app not open**. The quota is attached to the manufacturer's account, not our request volume. Nothing pecron-monitor can do about it besides waiting for 00:00 UTC.
 
 If this affects your usage pattern, the 23:00 UTC window is a poor time to rely on automations that send control commands. The monitor continues running and will resume normal operation once the Pecron cloud clears its quota.
 
@@ -37,19 +37,19 @@ If this affects your usage pattern, the 23:00 UTC window is a poor time to rely 
 **First documented by:** [@brucehoult in pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
 **Affects:** Any calculation using `BATTERY_CAPACITY_WH`
 
-The "3600" in E3600LFP is the inverter wattage, not the battery capacity. The actual LiFePO4 pack is 3072Wh — identical to the F3000LFP. Easy to get wrong because every other model in the lineup names itself after the pack size (E1500LFP = 1536Wh, E3800LFP = 3840Wh, etc.). v0.7.0 shipped the wrong value; v0.7.2 corrects it.
+The "3600" in E3600LFP is the inverter wattage, not the battery capacity. The actual LiFePO4 pack is 3072Wh, identical to the F3000LFP. Easy to get wrong because every other model in the lineup names itself after the pack size (E1500LFP = 1536Wh, E3800LFP = 3840Wh, etc.). v0.7.0 shipped the wrong value; v0.7.2 corrects it.
 
 ## E3600LFP / E3800LFP telemetry arrives in alternating MQTT packets
 
 **First documented here:** [pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
 **Affects:** Cloud MQTT on E3600LFP and E3800LFP
 
-On these two models the cloud sends telemetry in 2-3 alternating packet shapes spaced roughly 10-15 seconds apart. A single MQTT message will contain only battery+status, or only voltage+power, or only settings — never everything in one payload. Clients that request data once and wait a fixed interval will see a partial picture.
+On these two models the cloud sends telemetry in 2-3 alternating packet shapes spaced roughly 10-15 seconds apart. A single MQTT message will contain only battery+status, or only voltage+power, or only settings, never everything in one payload. Clients that request data once and wait a fixed interval will see a partial picture.
 
 pecron-monitor works around this by:
 
 1. Enabling `high_frequency_reporting=3` at startup for a short warm-up window (see `high_freq_warmup_seconds` in `config.yaml`, default 60s) so the full packet sequence arrives quickly.
-2. Disabling it again after warm-up — see the next quirk for why.
+2. Disabling it again after warm-up (see the next quirk for why).
 3. Merging partial packets with a last-known-good cache (`_state_cache` in `ha_bridge.py`) so Home Assistant entities don't flap to `unknown` between packets.
 
 ## Persistent `high_frequency_reporting=3` burns cloud quota (error 4026)
@@ -61,7 +61,7 @@ Leaving `high_frequency_reporting` enabled indefinitely eventually returns error
 
 If you set `high_freq_warmup_seconds: 0`, be aware that slow devices (E3600/E3800 per above) may never produce a complete status log, and setting it to a very large number risks tripping 4026.
 
-## `code 4007 — "device is not bound"` is frequently a false positive
+## `code 4007 "device is not bound"` is frequently a false positive
 
 **First documented here:** `monitor.py:549`
 **Affects:** REST API and cloud MQTT control traffic
@@ -84,4 +84,4 @@ Unlike the E1500LFP (which returns the full property set in a single local read)
 **First documented here:** incidentally, in this repo's setup-wizard output
 **Affects:** All models seen so far
 
-The 12-hex-char `deviceKey` returned by the cloud device-list API is the same as the Wi-Fi MAC address burned into the device's radio. `device_key=682499E40D61` appears on the LAN as MAC `68:24:99:e4:0d:61`. This is useful for LAN auto-discovery (see `lan_scan.py`) — a single subnet ARP scan is enough to locate every bound device, no active handshake needed.
+The 12-hex-char `deviceKey` returned by the cloud device-list API is the same as the Wi-Fi MAC address burned into the device's radio. `device_key=682499E40D61` appears on the LAN as MAC `68:24:99:e4:0d:61`. This is useful for LAN auto-discovery (see `lan_scan.py`): a single subnet ARP scan is enough to locate every bound device, no active handshake needed.

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -46,7 +46,7 @@ class HomeAssistantBridge:
         self._last_state = {}  # device_key -> dict
 
     def connect(self):
-        """Initial connection attempt. If it fails the bridge is not fatal —
+        """Initial connection attempt. If it fails the bridge is not fatal;
         the monitor's main loop will call try_reconnect() periodically."""
         self._last_retry_at = time.time()
         self._connect_attempt()
@@ -109,7 +109,7 @@ class HomeAssistantBridge:
             client.loop_start()
             self.client = client
         except (ConnectionRefusedError, OSError) as e:
-            log.error("Cannot connect to MQTT broker at %s:%d — %s. Will retry every %ds.",
+            log.error("Cannot connect to MQTT broker at %s:%d (%s). Will retry every %ds.",
                       host, port, e, self._retry_interval)
             self._connected = False
             self.client = None

--- a/monitor.py
+++ b/monitor.py
@@ -72,7 +72,7 @@ class PecronMonitor:
 
         # Cloud recovery state (issue #23). _fell_back_to_offline distinguishes
         # an unplanned fallback (transient DNS/network failure during cloud login)
-        # from a user-requested offline run — only the former should be retried.
+        # from a user-requested offline run. Only the former should be retried.
         self._fell_back_to_offline = False
         self._last_cloud_retry_at = 0.0
 
@@ -1161,7 +1161,7 @@ class PecronMonitor:
             # If we haven't received MQTT data for this device yet, try REST API.
             # In rest_only mode there is no MQTT or local TCP, so we must re-fetch
             # every poll rather than only on the first time (fix from @brucehoult
-            # in issue #14 — otherwise --rest-only stops updating after cycle 1).
+            # in issue #14; otherwise --rest-only stops updating after cycle 1).
             if self.rest_only or dk not in self.latest_data:
                 if self.token_data:  # Only available if not in offline mode
                     log.debug("Fetching status via REST API for %s (rest_only=%s, cached=%s)...",
@@ -1207,12 +1207,12 @@ class PecronMonitor:
             log.info("Cloud retry failed: %s (next attempt in %ds)", e, interval)
             return False
 
-        # Phase 2: login succeeded — apply state and rebuild MQTT/local transports.
+        # Phase 2: login succeeded. Apply state and rebuild MQTT/local transports.
         self.token_data = token
         self.devices = devices
         self.offline_mode = False
         self._fell_back_to_offline = False
-        log.info("Cloud recovered — reconnecting MQTT")
+        log.info("Cloud recovered, reconnecting MQTT")
         try:
             if not self.skip_local_setup:
                 self._setup_local_transports()
@@ -1330,7 +1330,7 @@ class PecronMonitor:
     @staticmethod
     def _high_freq_effective(device: dict) -> bool:
         """Return False for models where high_frequency_reporting is a known no-op
-        (issue #14 — E3600LFP ignores the setting; don't waste cloud requests)."""
+        (issue #14: E3600LFP ignores the setting; don't waste cloud requests)."""
         name = device.get("device_name") or device.get("product_name") or ""
         return MODEL_BEHAVIOR.get(name, {}).get("high_freq_effective", True)
 
@@ -1343,7 +1343,7 @@ class PecronMonitor:
         effective = [d for d in self.devices if self._high_freq_effective(d)]
         skipped = [d for d in self.devices if not self._high_freq_effective(d)]
         for d in skipped:
-            log.debug("Skipping high-freq enable for %s — ineffective on this model (issue #14)",
+            log.debug("Skipping high-freq enable for %s (ineffective on this model, issue #14)",
                       d.get("device_name") or d["device_key"])
         for i, d in enumerate(effective):
             dk = d["device_key"]
@@ -1593,9 +1593,9 @@ class PecronMonitor:
         if not self.latest_data:
             print("No data received — device may be offline.")
 
-        # Leave the device in its normal cadence — don't strand it in high-freq
-        # mode after a one-shot --status run (would burn cloud quota if another
-        # process checks status often). Cheap no-op for skipped models.
+        # Leave the device in its normal cadence. Don't strand it in high-freq
+        # mode after a one-shot --status run; that would burn cloud quota if
+        # another process checks status often. Cheap no-op for skipped models.
         if self.mqtt_client:
             self._disable_high_freq_reporting()
             self.mqtt_client.loop_stop()

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     python pecron_monitor.py --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 
 import argparse
 import json


### PR DESCRIPTION
## Summary
Rolls today's three PRs (#26 + #27 + #28) up into a single minor-version release.

The cumulative changes are new config surface (`cloud_retry_interval`, `homeassistant.retry_interval`), a new per-model behavior system (`MODEL_BEHAVIOR`), and user-visible retry + skip behavior. Repo precedent (0.5.x → 0.6.0 for the MQTT data-delivery rework) supports a minor bump for that scope.

## What changes
- `pecron_monitor.py`: `__version__` 0.7.2 to 0.8.0.
- `README.md`: version header points at v0.8.0 with a link to `/releases/latest`.
- `CHANGELOG.md`: new 0.8.0 header above the existing 0.7.1 + 0.7.2 sections. Those two entries stay intact for audit history.
- Punctuation cleanup: em dashes removed from the comments, docs, README sections, and CHANGELOG entries added in this series, per maintainer preference. Pre-existing code untouched.

## Not in scope
No code behavior change relative to 0.7.2. This is a release bump + polish pass.

## Test plan
- [x] Existing unit tests pass (`test_offline_retry.py`, `test_model_behavior.py`).
- [x] `python3 pecron_monitor.py --version` reports 0.8.0.
- [x] Stills production service continues running unchanged (no code diff to the logic it executes).

After merge: tag `v0.8.0` on main and create a GitHub release marked `--latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)