### PR TITLE
revert: undo 0.8.0 version bump, restore 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to pecron-monitor are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
-## [0.8.0] - 2026-04-19
-
-Consolidates the 0.7.1 and 0.7.2 reliability work into a single release so users pinning versions see a clear signal for the new retry loops, the new config knobs, and the new per-model behavior system. No code differences from 0.7.2 itself.
-
 ## [0.7.2] - 2026-04-19
 
 Targeted E3600LFP follow-ups from #14, informed by detailed testing and debugging from @brucehoult and @derekclawson.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.8.0** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest)
+**v0.7.2** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     python pecron_monitor.py --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.8.0"
+__version__ = "0.7.2"
 
 import argparse
 import json


### PR DESCRIPTION
Reverts the version string and related surface from #32. Em-dash cleanup is preserved because that was an independent ask.

## Why
Miscommunication on my part in the 0.8.0 PR. The original ask was to publish the existing v0.7.2 as a GitHub Release so the sidebar updates past v0.7.0, not to cut a new minor version.

## What changes
- `pecron_monitor.py`: `__version__` 0.8.0 to 0.7.2.
- `README.md`: version header back to v0.7.2.
- `CHANGELOG.md`: remove the 0.8.0 entry. 0.7.1 and 0.7.2 sections stay intact.

No code behavior change relative to 0.7.2 or 0.8.0 (both were identical).

## Follow-up after merge
- Delete the v0.8.0 tag (origin + local mirrors) and the v0.8.0 GitHub Release.
- Retroactively tag v0.7.1 at 1b34e60 and v0.7.2 at e30f1b1.
- Publish both as GitHub Releases (v0.7.2 as `--latest`).