### PR TITLE
feat: group HA entities into Configuration / Diagnostic sections (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to pecron-monitor are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [0.7.3] - 2026-04-19
+
+### Changed
+- **Home Assistant device view now groups entities into Configuration / Diagnostic sections** (#34). Non-essential entities (UPS mode, screen brightness, per-pack voltages, battery temps, AC output voltage/frequency, etc.) get HA's standard `entity_category` hint in their MQTT discovery payload, so HA collapses them under labeled sections instead of flooding the main device view with 40+ entries. Everyday readings (battery %, voltage, temperature, total power in/out, AC/DC switches, remaining time) stay in the main view as before. No config changes needed. Pull, restart, HA reorganizes automatically.
+
 ## [0.7.2] - 2026-04-19
 
 Targeted E3600LFP follow-ups from #14, informed by detailed testing and debugging from @brucehoult and @derekclawson.

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -23,6 +23,73 @@ from constants import (SENSOR_FIELDS, DEVICE_STATUS_LABELS, FAULT_ALARM_LABELS,
 log = logging.getLogger("pecron")
 
 
+# Home Assistant device view categorization for MQTT discovery (issue #34).
+# Entities in this map get an `entity_category` hint on discovery so HA
+# groups them under collapsible Configuration / Diagnostic sections instead
+# of flooding the main device view. Keys omitted here default to the main
+# view. Pack-level sensors (pack_N_*) are routed to diagnostic via a prefix
+# rule in entity_category_for() below so we don't need 20 lines of per-pack
+# entries here.
+ENTITY_CATEGORIES = {
+    # Configuration: knobs set rarely, not part of the daily glance.
+    "ups": "config",
+    "eco_mode": "config",
+    "touch_lock": "config",
+    "bypass": "config",
+    "auto_dim": "config",
+    "beep": "config",
+    "ac_charging_power": "config",
+    "ups_charge_threshold": "config",
+    "standby_timeout": "config",
+    "screen_brightness": "config",
+    "ac_voltage_setting": "config",
+    "ac_frequency_setting": "config",
+    "ac_output_voltage": "config",
+    "ac_output_hz": "config",
+    "auto_off_timer": "config",
+    "charging_limit_voltage": "config",
+    "discharge_limit_voltage": "config",
+    "charging_current_limit": "config",
+    "discharge_current_limit": "config",
+    "battery_heating": "config",
+    # Diagnostic: detail, only looked at when debugging.
+    "host_battery": "diagnostic",
+    "battery_temp": "diagnostic",
+    "charging_plate_temp": "diagnostic",
+    "inverter_temp": "diagnostic",
+    "ac_input": "diagnostic",
+    "dc_input": "diagnostic",
+    "ac_output_pf": "diagnostic",
+    "dc5521_input_voltage": "diagnostic",
+    "dc5521_input_current": "diagnostic",
+    "dc5521_input_power": "diagnostic",
+    "gx16mf1_input_voltage": "diagnostic",
+    "gx16mf1_input_current": "diagnostic",
+    "gx16mf1_input_power": "diagnostic",
+    "gx16mf2_input_voltage": "diagnostic",
+    "gx16mf2_input_current": "diagnostic",
+    "gx16mf2_input_power": "diagnostic",
+    "remaining_charging_time": "diagnostic",  # duplicates remaining_time due to Pecron API bug (jsight issue #1)
+    "device_status": "diagnostic",
+    "expansion_pack": "diagnostic",
+    "fault_alarm": "diagnostic",
+}
+
+# Prefix match for per-pack sensors (pack_0_battery, pack_1_voltage, etc.)
+_DIAGNOSTIC_PREFIXES = ("pack_",)
+
+
+def entity_category_for(key: str):
+    """Return the HA entity_category ('config' / 'diagnostic') for an entity key,
+    or None if the entity should stay in the main device view."""
+    if key in ENTITY_CATEGORIES:
+        return ENTITY_CATEGORIES[key]
+    for prefix in _DIAGNOSTIC_PREFIXES:
+        if key.startswith(prefix):
+            return "diagnostic"
+    return None
+
+
 class HomeAssistantBridge:
     """Publishes Home Assistant MQTT auto-discovery config and state updates."""
 
@@ -788,6 +855,12 @@ class HomeAssistantBridge:
         log.info("Published Home Assistant discovery configs")
 
     def _pub_config(self, component: str, dk: str, key: str, config: dict):
+        # Issue #34: collapse non-essential entities under HA's Configuration /
+        # Diagnostic sections. Applied here so every call site benefits without
+        # 50 per-call-site edits.
+        category = entity_category_for(key)
+        if category and "entity_category" not in config:
+            config = {**config, "entity_category": category}
         topic = f"{self.discovery_prefix}/{component}/pecron_{dk}/{key}/config"
         self.client.publish(topic, json.dumps(config), qos=1, retain=True)
         self._published_topics.add(topic)

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     python pecron_monitor.py --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 import argparse
 import json

--- a/test_entity_categories.py
+++ b/test_entity_categories.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tests for HA entity_category hint routing (issue #34).
+
+Verifies that non-essential entities get bucketed under HA's Configuration /
+Diagnostic sections via entity_category, while primary entities stay in the
+main device view.
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+sys.modules["paho"] = MagicMock()
+sys.modules["paho.mqtt"] = MagicMock()
+sys.modules["paho.mqtt.client"] = MagicMock()
+
+from ha_bridge import HomeAssistantBridge, ENTITY_CATEGORIES, entity_category_for  # noqa: E402
+
+
+class TestEntityCategoryHelper(unittest.TestCase):
+    """entity_category_for() routing: main view for daily-glance entities,
+    config for rarely-touched knobs, diagnostic for detail readouts."""
+
+    def test_primary_entities_default_to_main_view(self):
+        for key in ["battery", "voltage", "temperature", "ac", "dc",
+                    "remaining_time", "total_input", "total_output",
+                    "current", "total_energy"]:
+            self.assertIsNone(entity_category_for(key),
+                              f"{key!r} should stay in main view (no category)")
+
+    def test_config_entities(self):
+        for key in ["ups", "eco_mode", "touch_lock", "bypass", "auto_dim",
+                    "screen_brightness", "ac_output_voltage", "ac_output_hz",
+                    "charging_limit_voltage", "battery_heating", "beep"]:
+            self.assertEqual(entity_category_for(key), "config",
+                             f"{key!r} should be in Configuration section")
+
+    def test_diagnostic_entities(self):
+        for key in ["host_battery", "battery_temp", "charging_plate_temp",
+                    "inverter_temp", "ac_input", "dc_input",
+                    "remaining_charging_time", "fault_alarm", "device_status"]:
+            self.assertEqual(entity_category_for(key), "diagnostic",
+                             f"{key!r} should be in Diagnostic section")
+
+    def test_pack_sensors_are_diagnostic_by_prefix(self):
+        for n in range(4):
+            for suffix in ["battery", "voltage", "current", "temp", "status"]:
+                key = f"pack_{n}_{suffix}"
+                self.assertEqual(entity_category_for(key), "diagnostic",
+                                 f"{key!r} should be Diagnostic via pack_ prefix")
+
+    def test_unknown_key_stays_in_main_view(self):
+        # Future new entity types should default to main view without opting in.
+        self.assertIsNone(entity_category_for("some_future_entity"))
+        self.assertIsNone(entity_category_for(""))
+
+
+class TestPubConfigInjectsCategory(unittest.TestCase):
+    """_pub_config() should inject entity_category into the discovery payload
+    for categorized keys, leaving primary keys untouched."""
+
+    def _make_bridge(self):
+        b = HomeAssistantBridge({"discovery_prefix": "homeassistant"}, devices=[])
+        b.client = MagicMock()
+        b._published_topics = set()
+        return b
+
+    def _last_published_payload(self, bridge):
+        # client.publish(topic, json_str, qos=1, retain=True) captured via mock
+        args, kwargs = bridge.client.publish.call_args
+        return json.loads(args[1])
+
+    def test_primary_entity_not_tagged(self):
+        b = self._make_bridge()
+        b._pub_config("sensor", "DEADBEEF", "battery", {"name": "Battery"})
+        payload = self._last_published_payload(b)
+        self.assertNotIn("entity_category", payload,
+                         "Primary entities must not get a category")
+
+    def test_config_entity_tagged(self):
+        b = self._make_bridge()
+        b._pub_config("switch", "DEADBEEF", "ups", {"name": "UPS"})
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("entity_category"), "config")
+
+    def test_diagnostic_entity_tagged(self):
+        b = self._make_bridge()
+        b._pub_config("sensor", "DEADBEEF", "battery_temp", {"name": "Batt Temp"})
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("entity_category"), "diagnostic")
+
+    def test_pack_entity_tagged_diagnostic(self):
+        b = self._make_bridge()
+        b._pub_config("sensor", "DEADBEEF", "pack_2_voltage", {"name": "Pack 2 V"})
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("entity_category"), "diagnostic")
+
+    def test_explicit_category_in_payload_is_preserved(self):
+        # If a call site already set entity_category explicitly, don't overwrite.
+        b = self._make_bridge()
+        b._pub_config("sensor", "DEADBEEF", "battery_temp",
+                      {"name": "Batt Temp", "entity_category": "config"})
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("entity_category"), "config",
+                         "Explicit category in call-site payload must win")
+
+    def test_publish_call_shape_unchanged(self):
+        """Ensure we didn't accidentally break qos/retain/topic construction."""
+        b = self._make_bridge()
+        b._pub_config("sensor", "DEADBEEF", "battery", {"name": "Battery"})
+        args, kwargs = b.client.publish.call_args
+        self.assertEqual(args[0], "homeassistant/sensor/pecron_DEADBEEF/battery/config")
+        self.assertEqual(kwargs.get("qos"), 1)
+        self.assertEqual(kwargs.get("retain"), True)
+
+
+class TestCategoryCoverage(unittest.TestCase):
+    """Sanity: every key in ENTITY_CATEGORIES maps to one of the two HA-supported
+    category values. Typos in the map (e.g. 'configuration' vs 'config') would
+    cause HA to ignore the field silently."""
+
+    def test_only_valid_category_values(self):
+        for key, cat in ENTITY_CATEGORIES.items():
+            self.assertIn(cat, ("config", "diagnostic"),
+                          f"{key!r}: {cat!r} is not a valid HA entity_category")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #34.

## Summary
Home Assistant device pages for Pecron devices currently flood the main view with 40+ entities all at the same level. This PR adds HA's standard `entity_category` hint to MQTT discovery payloads for entities that belong under collapsible Configuration and Diagnostic sections, leaving primary glance-worthy entities in the main view.

No config changes for end users. Pull, restart, HA reorganizes the device pages automatically on the next discovery sweep.

## What moves where

**Stays in main view** (primary, default):
battery %, voltage, temperature, AC switch, DC switch, remaining time, total input/output power, current (amps), total energy (solar).

**Configuration section** (collapsed):
UPS mode, eco mode, touch lock, bypass, auto-dim, screen brightness, AC output voltage/frequency, AC charging power, UPS charge threshold, standby timeout, auto-off timer, charge/discharge limits, battery heating mode, buzzer.

**Diagnostic section** (collapsed):
host battery, battery temp, charging plate temp, inverter temp, AC input power, DC input power, AC output power factor, per-port DC inputs (5521 barrel jack, GX16-MF1, GX16-MF2), remaining charging time, device status enum, expansion pack presence, fault alarm, per-pack voltages / currents / temps / status (pack_N_*).

## Implementation
- New module-level `ENTITY_CATEGORIES` dict and `entity_category_for()` helper at the top of `ha_bridge.py`. Keys omitted default to main view.
- Per-pack sensors match via a prefix rule so we don't need 20 lines of hardcoded `pack_0_battery`, `pack_0_voltage`, etc.
- `_pub_config()` gets three lines that inject the category into the payload when applicable. If a call site already set `entity_category` explicitly, the explicit value wins.
- Every existing `_pub_config` call site benefits without edits.

## Test plan
- [x] 12 new unit tests in `test_entity_categories.py` covering primary-entities-stay-main, config routing, diagnostic routing, pack prefix match, explicit-category-preserved, publish topic/qos/retain unchanged, and map-value sanity (every categorization is one of the two HA-valid values).
- [x] Pre-existing tests still pass (`test_offline_retry.py`, `test_model_behavior.py`).
- [ ] Deploy to Stills hardware, observe HA device pages for E1500LFP and E3800LFP reorganize into the expected sections. Requires visual inspection in HA UI; will do that after merge.

## Not addressed here (follow-ups)
- #35: E1500LFP showing "Unknown" for 10+ entities it doesn't actually support. That's a discovery gating issue (conditionally publish based on device TSL), separate surface.
- #36: Random 0.0V readings landing in HA when local TCP returns a settings-only packet. That's a state-publish filtering issue, separate surface.

Both filed as their own issues to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)