### PR TITLE
docs: link project board from README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.7.2** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest)
+**v0.7.2** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 


### PR DESCRIPTION
Adds a third link to the README header (alongside Changelog and Latest release) pointing at the newly-public GitHub Projects board at https://github.com/users/attractify-logan/projects/1.

Single-line change. No code, no version bump.

Context: set up the Projects v2 board to track backlog items without requiring every idea to be filed as a public GitHub issue. Drafts on the board stay private-to-the-project until promoted to an issue. Linking from the README so contributors find it naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)