### PR TITLE
fix: gate HA discovery on device TSL to kill ghost Unknown entities (#35)

### DIFF
--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -874,9 +874,23 @@ class HomeAssistantBridge:
         named resource codes. Used to gate HA discovery publication so models
         that lack a TSL property don't end up with perpetual 'Unknown' entities
         (issue #35). Pass multiple codes when a single entity maps to whichever
-        one the firmware exposes (e.g. 'battery_percentage' vs 'battery')."""
+        one the firmware exposes (e.g. 'battery_percentage' vs 'battery').
+
+        Logs at DEBUG when gating skips a code so users who run with --verbose
+        can see why an entity they expected isn't appearing. The suggested
+        remediation is to re-run --setup which refreshes the TSL cache from
+        the Pecron cloud (new firmware sometimes adds resource codes).
+        """
         controls = device.get("controls", {}) or {}
-        return any(code in controls for code in resource_codes)
+        has = any(code in controls for code in resource_codes)
+        if not has:
+            log.debug(
+                "TSL gate: device %s lacks %s, skipping entity publish "
+                "(re-run --setup if this should be present)",
+                device.get("device_key", "?"),
+                " or ".join(resource_codes),
+            )
+        return has
 
     def _pub_config(self, component: str, dk: str, key: str, config: dict):
         # Issue #34: collapse non-essential entities under HA's Configuration /

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -270,8 +270,10 @@ class HomeAssistantBridge:
                 "unique_id": f"pecron_{dk}_temperature",
             })
 
-            # E3800-specific temperature sensors (3 separate sensors)
-            if is_pps:
+            # E3800-specific temperature sensors. Gated on TSL presence so
+            # models that don't expose these properties (E1500, etc.) don't
+            # show permanent 'Unknown' entities in HA (issue #35).
+            if is_pps and self._has(device, "battery_temp"):
                 self._pub_config("sensor", dk, "battery_temp", {
                     "name": "Battery Temperature",
                     "device_class": "temperature",
@@ -282,6 +284,7 @@ class HomeAssistantBridge:
                     "unique_id": f"pecron_{dk}_battery_temp",
                 })
 
+            if is_pps and self._has(device, "charging_plate_temp"):
                 self._pub_config("sensor", dk, "charging_plate_temp", {
                     "name": "Charging Plate Temperature",
                     "device_class": "temperature",
@@ -292,6 +295,7 @@ class HomeAssistantBridge:
                     "unique_id": f"pecron_{dk}_charging_plate_temp",
                 })
 
+            if is_pps and self._has(device, "inverter_temp"):
                 self._pub_config("sensor", dk, "inverter_temp", {
                     "name": "Inverter Temperature",
                     "device_class": "temperature",
@@ -392,64 +396,71 @@ class HomeAssistantBridge:
             # (HA will just show "unavailable" if the device doesn't report them)
 
             if is_pps:
-                # Eco/Quiet mode switch
-                self._pub_config("switch", dk, "eco_mode", {
-                    "name": "Eco Mode",
-                    "icon": "mdi:leaf",
-                    "command_topic": f"pecron/{dk}/eco_mode/set",
-                    "state_topic": f"pecron/{dk}/state",
-                    "value_template": "{{ value_json.eco_quite_mode_as }}",
-                    "state_on": "ON", "state_off": "OFF",
-                    "payload_on": "ON", "payload_off": "OFF",
-                    "device": dev_info,
-                    "unique_id": f"pecron_{dk}_eco_mode",
-                })
+                # Eco/Quiet mode switch (E3800 TSL has eco_quite_mode_as; E1500 does not)
+                if self._has(device, "eco_quite_mode_as"):
+                    self._pub_config("switch", dk, "eco_mode", {
+                        "name": "Eco Mode",
+                        "icon": "mdi:leaf",
+                        "command_topic": f"pecron/{dk}/eco_mode/set",
+                        "state_topic": f"pecron/{dk}/state",
+                        "value_template": "{{ value_json.eco_quite_mode_as }}",
+                        "state_on": "ON", "state_off": "OFF",
+                        "payload_on": "ON", "payload_off": "OFF",
+                        "device": dev_info,
+                        "unique_id": f"pecron_{dk}_eco_mode",
+                    })
 
-                # Touch panel lock
-                self._pub_config("switch", dk, "touch_lock", {
-                    "name": "Touch Panel Lock",
-                    "icon": "mdi:lock",
-                    "command_topic": f"pecron/{dk}/touch_lock/set",
-                    "state_topic": f"pecron/{dk}/state",
-                    "value_template": "{{ value_json.device_touch_locking_as }}",
-                    "state_on": "ON", "state_off": "OFF",
-                    "payload_on": "ON", "payload_off": "OFF",
-                    "device": dev_info,
-                    "unique_id": f"pecron_{dk}_touch_lock",
-                })
+                # Touch panel lock (E3800-only)
+                if self._has(device, "device_touch_locking_as"):
+                    self._pub_config("switch", dk, "touch_lock", {
+                        "name": "Touch Panel Lock",
+                        "icon": "mdi:lock",
+                        "command_topic": f"pecron/{dk}/touch_lock/set",
+                        "state_topic": f"pecron/{dk}/state",
+                        "value_template": "{{ value_json.device_touch_locking_as }}",
+                        "state_on": "ON", "state_off": "OFF",
+                        "payload_on": "ON", "payload_off": "OFF",
+                        "device": dev_info,
+                        "unique_id": f"pecron_{dk}_touch_lock",
+                    })
 
-                # AC charging power level
-                self._pub_config("sensor", dk, "ac_charging_power", {
-                    "name": "AC Charging Power Setting",
-                    "icon": "mdi:flash",
-                    "state_topic": f"pecron/{dk}/state",
-                    "value_template": "{{ value_json.ac_charging_power_ios }}",
-                    "device": dev_info,
-                    "unique_id": f"pecron_{dk}_ac_charging_power",
-                })
+                # AC charging power level (E3800-only)
+                if self._has(device, "ac_charging_power_ios"):
+                    self._pub_config("sensor", dk, "ac_charging_power", {
+                        "name": "AC Charging Power Setting",
+                        "icon": "mdi:flash",
+                        "state_topic": f"pecron/{dk}/state",
+                        "value_template": "{{ value_json.ac_charging_power_ios }}",
+                        "device": dev_info,
+                        "unique_id": f"pecron_{dk}_ac_charging_power",
+                    })
 
-                # UPS charge threshold
-                self._pub_config("sensor", dk, "ups_charge_threshold", {
-                    "name": "UPS Charge Threshold",
-                    "icon": "mdi:battery-charging",
-                    "unit_of_measurement": "%",
-                    "state_topic": f"pecron/{dk}/state",
-                    "value_template": "{{ value_json.ups_start_charge_value_as }}",
-                    "device": dev_info,
-                    "unique_id": f"pecron_{dk}_ups_charge_threshold",
-                })
+                # UPS charge threshold (E3800-only)
+                if self._has(device, "ups_start_charge_value_as"):
+                    self._pub_config("sensor", dk, "ups_charge_threshold", {
+                        "name": "UPS Charge Threshold",
+                        "icon": "mdi:battery-charging",
+                        "unit_of_measurement": "%",
+                        "state_topic": f"pecron/{dk}/state",
+                        "value_template": "{{ value_json.ups_start_charge_value_as }}",
+                        "device": dev_info,
+                        "unique_id": f"pecron_{dk}_ups_charge_threshold",
+                    })
 
-                # Standby timeout
-                self._pub_config("sensor", dk, "standby_timeout", {
-                    "name": "Standby Timeout",
-                    "icon": "mdi:timer-sand",
-                    "state_topic": f"pecron/{dk}/state",
-                    "value_template": "{{ value_json.device_standy_times_as }}",
-                    "device": dev_info,
-                    "unique_id": f"pecron_{dk}_standby_timeout",
-                })
+                # Standby timeout (WB12200 + E3800 TSL have device_standy_times_as; E1500 does not)
+                if self._has(device, "device_standy_times_as"):
+                    self._pub_config("sensor", dk, "standby_timeout", {
+                        "name": "Standby Timeout",
+                        "icon": "mdi:timer-sand",
+                        "state_topic": f"pecron/{dk}/state",
+                        "value_template": "{{ value_json.device_standy_times_as }}",
+                        "device": dev_info,
+                        "unique_id": f"pecron_{dk}_standby_timeout",
+                    })
 
-                # Bypass mode
+                # Bypass mode (bypass_enable isn't a standard TSL code on any model
+                # I've seen; leaving ungated for now, will gate if someone identifies
+                # the underlying TSL resource)
                 self._pub_config("switch", dk, "bypass", {
                     "name": "Bypass Mode",
                     "icon": "mdi:transfer",
@@ -631,17 +642,20 @@ class HomeAssistantBridge:
                 "unique_id": f"pecron_{dk}_remaining_charging_time",
             })
 
-            # Total energy (cumulative PV generation)
-            self._pub_config("sensor", dk, "total_energy", {
-                "name": "Total PV Energy",
-                "device_class": "energy",
-                "state_class": "total_increasing",
-                "unit_of_measurement": "kWh",
-                "state_topic": f"pecron/{dk}/state",
-                "value_template": "{{ value_json.total_energy }}",
-                "device": dev_info,
-                "unique_id": f"pecron_{dk}_total_energy",
-            })
+            # Total energy (cumulative PV generation). Only on models with
+            # PV input reporting (E3800, F-series). E1500 and WB12200 do
+            # not expose total_energy in their TSL (issue #35).
+            if self._has(device, "total_energy"):
+                self._pub_config("sensor", dk, "total_energy", {
+                    "name": "Total PV Energy",
+                    "device_class": "energy",
+                    "state_class": "total_increasing",
+                    "unit_of_measurement": "kWh",
+                    "state_topic": f"pecron/{dk}/state",
+                    "value_template": "{{ value_json.total_energy }}",
+                    "device": dev_info,
+                    "unique_id": f"pecron_{dk}_total_energy",
+                })
 
             # Device status
             self._pub_config("sensor", dk, "device_status", {
@@ -853,6 +867,16 @@ class HomeAssistantBridge:
             self._clear_stale_entities(dk)
 
         log.info("Published Home Assistant discovery configs")
+
+    @staticmethod
+    def _has(device: dict, *resource_codes: str) -> bool:
+        """Return True if the device's TSL cache includes at least one of the
+        named resource codes. Used to gate HA discovery publication so models
+        that lack a TSL property don't end up with perpetual 'Unknown' entities
+        (issue #35). Pass multiple codes when a single entity maps to whichever
+        one the firmware exposes (e.g. 'battery_percentage' vs 'battery')."""
+        controls = device.get("controls", {}) or {}
+        return any(code in controls for code in resource_codes)
 
     def _pub_config(self, component: str, dk: str, key: str, config: dict):
         # Issue #34: collapse non-essential entities under HA's Configuration /

--- a/test_tsl_gating.py
+++ b/test_tsl_gating.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Tests for TSL-based entity gating (issue #35).
+
+Verifies the _has() helper that decides whether a given device has a specific
+TSL resource code, so HA discovery skips entities the device doesn't actually
+support instead of emitting them and letting HA show 'Unknown' forever.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+sys.modules["paho"] = MagicMock()
+sys.modules["paho.mqtt"] = MagicMock()
+sys.modules["paho.mqtt.client"] = MagicMock()
+
+from ha_bridge import HomeAssistantBridge  # noqa: E402
+
+
+# Realistic TSL caches pulled from the live devices on Stills.
+E1500_TSL = {
+    "battery_percentage": {}, "remain_time": {}, "remain_charging_time": {},
+    "total_input_power": {}, "total_output_power": {}, "ac_switch_hm": {},
+    "dc_switch_hm": {}, "ups_status_hm": {}, "device_status_hm": {},
+    "auto_light_flag_as": {}, "add_bat_status_hm": {},
+    "ac_data_input_hm": {}, "dc_data_input_hm": {},
+    "ac_data_output_hm": {}, "dc_data_output_hm": {},
+    "ac_output_voltage_io": {}, "ac_output_frequency_io": {},
+    "noastime_io": {}, "machine_screen_light_as": {},
+    "charging_pack_data_jdb": {}, "host_packet_data_jdb": {},
+    "device_manual": {}, "high_frequency_reporting": {},
+}
+
+E3800_TSL = {
+    **E1500_TSL,
+    # E3800-only additions
+    "battery_temp": {}, "charging_plate_temp": {}, "inverter_temp": {},
+    "eco_quite_mode_as": {}, "device_touch_locking_as": {},
+    "ac_charging_power_ios": {}, "ups_start_charge_value_as": {},
+    "device_standy_times_as": {}, "total_energy": {},
+    "timing_off_as": {}, "ota_ots": {},
+}
+
+
+class TestHasHelper(unittest.TestCase):
+
+    def test_present_code_returns_true(self):
+        device = {"controls": E3800_TSL}
+        self.assertTrue(HomeAssistantBridge._has(device, "battery_temp"))
+
+    def test_missing_code_returns_false(self):
+        device = {"controls": E1500_TSL}
+        self.assertFalse(HomeAssistantBridge._has(device, "battery_temp"))
+
+    def test_empty_controls_returns_false(self):
+        device = {"controls": {}}
+        self.assertFalse(HomeAssistantBridge._has(device, "battery_temp"))
+
+    def test_missing_controls_key_returns_false(self):
+        device = {}
+        self.assertFalse(HomeAssistantBridge._has(device, "battery_temp"))
+
+    def test_none_controls_returns_false(self):
+        device = {"controls": None}
+        self.assertFalse(HomeAssistantBridge._has(device, "battery_temp"))
+
+    def test_or_semantics_across_multiple_codes(self):
+        device = {"controls": E1500_TSL}
+        self.assertTrue(
+            HomeAssistantBridge._has(device, "battery_temp", "battery_percentage"),
+            "OR: at least one code present should return True"
+        )
+        self.assertFalse(
+            HomeAssistantBridge._has(device, "battery_temp", "unknown_code"),
+            "OR: all missing should return False"
+        )
+
+
+class TestE1500VsE3800Coverage(unittest.TestCase):
+    """The 9 TSL codes gated in ha_bridge.py are distinguishable E3800 vs E1500.
+    This protects against regressions where someone adds a new entity that
+    should be gated but forgets, or accidentally gates on a shared code."""
+
+    E3800_ONLY_CODES = [
+        "battery_temp",
+        "charging_plate_temp",
+        "inverter_temp",
+        "eco_quite_mode_as",
+        "device_touch_locking_as",
+        "ac_charging_power_ios",
+        "ups_start_charge_value_as",
+        "device_standy_times_as",
+        "total_energy",
+    ]
+
+    def test_e1500_lacks_all_gated_codes(self):
+        for code in self.E3800_ONLY_CODES:
+            self.assertNotIn(code, E1500_TSL,
+                             f"E1500 should not have {code!r}, if it does the gate rule is wrong")
+
+    def test_e3800_has_all_gated_codes(self):
+        for code in self.E3800_ONLY_CODES:
+            self.assertIn(code, E3800_TSL,
+                          f"E3800 must have {code!r} (otherwise gated entity never publishes)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #35.

## Problem
The E1500LFP's HA device page had ~10 ghost entities that would never have a value (Battery Temperature, Charging Plate Temperature, Inverter Temperature, Eco Mode, Touch Panel Lock, AC Charging Power, UPS Charge Threshold, Standby Timeout, Total PV Energy). Those entities existed in HA because ha_bridge was publishing discovery for them regardless of whether the specific device actually exposed the underlying TSL property. HA duly registered each one and showed "Unknown" forever since the state messages never came.

## Fix
Added a small helper and wrapped the 9 E3800-only call sites with a TSL presence check:

\`\`\`python
@staticmethod
def _has(device, *resource_codes):
    controls = device.get("controls", {}) or {}
    return any(code in controls for code in resource_codes)

# At each gated call site:
if is_pps and self._has(device, "battery_temp"):
    self._pub_config("sensor", dk, "battery_temp", { ... })
\`\`\`

## Entities gated (9)

| Entity | TSL resource code gated on | On E1500 before | After |
|---|---|---|---|
| battery_temp | \`battery_temp\` | Unknown forever | Not published |
| charging_plate_temp | \`charging_plate_temp\` | Unknown | Not published |
| inverter_temp | \`inverter_temp\` | Unknown | Not published |
| eco_mode | \`eco_quite_mode_as\` | Unknown | Not published |
| touch_lock | \`device_touch_locking_as\` | Unknown | Not published |
| ac_charging_power | \`ac_charging_power_ios\` | Unknown | Not published |
| ups_charge_threshold | \`ups_start_charge_value_as\` | Unknown | Not published |
| standby_timeout | \`device_standy_times_as\` | Unknown | Not published |
| total_energy | \`total_energy\` | Unknown | Not published |

E3800LFP behavior unchanged (it has all 9 codes). WB12200 behavior unchanged (the entire E3800-only block is already gated on \`is_pps\`, which excludes WB12200 regardless).

## Transition for existing users
\`_clear_stale_entities\` already handles the upgrade path: on first pecron-monitor restart after the update, entities no longer published get empty retained messages on their discovery topic, and HA removes them from the device page automatically. No manual HA-side action required.

## Test plan
- [x] 8 new unit tests in \`test_tsl_gating.py\` covering \`_has\` semantics (present/missing/empty/None controls, OR across multiple codes) plus a coverage guard asserting the 9 gated codes are absent from a realistic E1500 TSL and present in a realistic E3800 TSL.
- [x] Existing tests pass (\`test_entity_categories.py\`, \`test_offline_retry.py\`, \`test_model_behavior.py\`).
- [ ] Deploy to Stills, restart pecron-monitor, reload MQTT integration on the van HA, verify E1500 device page loses the 9 ghost entities and E3800 page is unchanged. Will do after merge.

## Not in this scope (deliberate)
- The \`bypass\` switch (\`value_json.bypass_enable\`) I couldn't map to a specific TSL resource code. Left ungated. If someone identifies the underlying TSL code, it's a one-line follow-up.
- The ghost per-pack sensors on standalone PPS (pack_0_battery=1% reading from phantom data) — that's a state-filter issue, not a discovery-gating issue. Tracked as a separate draft on the project board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)