### PR TITLE
fix: refresh soc_percent on standalone PPS host packets (#43)

### DIFF
--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -1266,14 +1266,22 @@ class HomeAssistantBridge:
                 except (TypeError, ValueError):
                     pass
 
-        # SOC fallback: on standalone PPS that only emit host-shape packets
-        # (e.g. E1500LFP) the "overall" SOC number never lands in cache, so
-        # HA's Battery (SOC) entity shows Unknown forever. When there are no
-        # expansion packs attached, overall SOC == host SOC by definition,
-        # so mirror host_percent into soc_percent whenever soc_percent isn't
-        # already populated. Devices with expansion packs still get their
-        # real soc_percent from whichever packet shape carries it.
-        if cache.get("soc_percent") is None and cache.get("host_percent") is not None:
+        # SOC fallback: on standalone PPS (no occupied expansion packs) the
+        # overall SOC and host % are by definition the same number, so mirror
+        # host_percent into soc_percent on every host-shape packet so HA tracks
+        # live state. Without this, a single "overall" packet that happened to
+        # arrive at a stale value (e.g. 100% reported just before the device
+        # went into shutdown) leaves soc_percent frozen at that value forever
+        # while host_percent updates live with every host-shape packet.
+        # Devices WITH expansion packs preserve the original "fill once, don't
+        # clobber" behavior: their overall SOC and host % can legitimately
+        # differ, and the explicit overall-shape reading is canonical.
+        # Pack processing runs earlier in this function, so pack_*_status in
+        # cache already reflects this packet's pack state when we get here.
+        has_pack = any(cache.get(f"pack_{i}_status") for i in range(4))
+        if cache.get("host_percent") is not None and (
+            not has_pack or cache.get("soc_percent") is None
+        ):
             cache["soc_percent"] = cache["host_percent"]
 
         # Ensure keys exist for HA templates (but don't force unknown -> 0)

--- a/tests/unit/test_ghost_suppression.py
+++ b/tests/unit/test_ghost_suppression.py
@@ -207,27 +207,79 @@ class TestSocFallback(unittest.TestCase):
                          "soc_percent must mirror host_percent when not independently set")
 
     def test_explicit_soc_not_overwritten_by_host(self):
-        """When the overall-shape packet provides soc_percent, don't clobber it with host."""
+        """Devices WITH expansion packs: overall SOC and host % can legitimately
+        differ; the explicit overall-shape reading must not be clobbered."""
         b = make_bridge()
-        # First packet: overall shape sets soc_percent (device with expansion
-        # pack reports distinct overall SOC).
-        kv_overall = {"battery_percentage": 85}  # no host_packet_data_jdb
+        connected_pack = {
+            "charging_pack_status": 3,  # balanced charging
+            "charging_pack_battery": 80,
+            "charging_pack_voltage": 53.0,
+            "charging_pack_current": 1.2,
+            "charging_pack_temp": 28,
+        }
+
+        # First packet: overall shape sets soc_percent. Pack data marks this as
+        # a non-standalone unit so the fallback preserves the explicit reading.
+        kv_overall = {
+            "battery_percentage": 85,
+            "charging_pack_data_jdb": [connected_pack, {"charging_pack_status": 4},
+                                       {"charging_pack_status": 4}, {"charging_pack_status": 4}],
+        }
         b.publish_state("DEV1", kv_overall)
         self.assertEqual(b._state_cache["DEV1"].get("soc_percent"), 85)
 
-        # Second packet: host shape with different host_percent. soc_percent
-        # is already populated, so fallback must not rewrite it to host_percent.
+        # Second packet: host shape with a different host_percent. soc_percent
+        # is already populated and a pack is occupied, so fallback must NOT
+        # rewrite it to host_percent.
         kv_host = {
             "host_packet_data_jdb": {
                 "host_packet_voltage": 53.1,
                 "host_packet_electric_percentage": 90,
-            }
+            },
+            "charging_pack_data_jdb": [connected_pack, {"charging_pack_status": 4},
+                                       {"charging_pack_status": 4}, {"charging_pack_status": 4}],
         }
         b.publish_state("DEV1", kv_host)
         cache = b._state_cache["DEV1"]
         self.assertEqual(cache.get("host_percent"), 90)
         self.assertEqual(cache.get("soc_percent"), 85,
-                         "explicit soc_percent must not be clobbered by host fallback")
+                         "explicit soc_percent must not be clobbered by host fallback "
+                         "on devices with expansion packs")
+
+    def test_standalone_pps_soc_refreshes_on_live_host_packet(self):
+        """Issue #43: standalone PPS (no expansion packs) must keep soc_percent
+        in sync with host_percent on every live host-shape packet, even after
+        a stale overall-shape packet has populated soc_percent.
+
+        Without this, a single overall packet (e.g. battery_percentage=100
+        reported as the device entered shutdown) freezes soc_percent forever
+        while host_percent continues updating from live cloud-MQTT host packets,
+        breaking any HA automation that watches the SOC sensor."""
+        b = make_bridge()
+
+        # Step 1: a stale overall-shape packet seeds cache with soc_percent=100
+        # (e.g. last value before the device went to shutdown). No pack data,
+        # so the device is treated as standalone.
+        kv_stale_overall = {"battery_percentage": 100}
+        b.publish_state("DEV1", kv_stale_overall)
+        self.assertEqual(b._state_cache["DEV1"].get("soc_percent"), 100,
+                         "initial overall packet should populate soc_percent")
+
+        # Step 2: live host-shape packet arrives showing the device is
+        # actually at 82%. soc_percent must follow because the device has
+        # no expansion packs.
+        kv_live_host = {
+            "host_packet_data_jdb": {
+                "host_packet_voltage": 52.5,
+                "host_packet_electric_percentage": 82,
+            },
+        }
+        b.publish_state("DEV1", kv_live_host)
+        cache = b._state_cache["DEV1"]
+        self.assertEqual(cache.get("host_percent"), 82)
+        self.assertEqual(cache.get("soc_percent"), 82,
+                         "standalone PPS soc_percent must follow host_percent "
+                         "on live host packets even after a prior overall packet")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #43.

## Summary

Standalone PPS units (E1500LFP and similar — no expansion packs) were freezing `soc_percent` in the published MQTT state at whatever value the first "overall" packet seeded, even while live host-shape packets continued updating `host_percent`. HA automations watching the SOC sensor saw a stuck value and never fired threshold triggers.

The host→soc mirror introduced in #41 only ran when `soc_percent` was None. As the issue points out, an overall packet at shutdown (often `battery_percentage=100`) populates `soc_percent` once and from that point on every live host packet's `host_packet_electric_percentage` updates `host_percent` but does not propagate to `soc_percent`.

## Fix

Differentiate standalone PPS from devices with expansion packs:

- Standalone (no occupied packs in cache): mirror `host_percent` → `soc_percent` on every host packet. Live state stays accurate.
- With packs: keep the original "fill once, don't clobber" behavior. Overall SOC and host % can legitimately differ on these units, and the explicit overall-shape reading is canonical.

Pack processing runs earlier in `publish_state` than the SOC mirror, so `pack_*_status` in cache reflects the current packet's pack state at the mirror site.

## Tests

- **Updated** `test_explicit_soc_not_overwritten_by_host` — the original test data was degenerate (no pack data, so under the new logic it would trip the standalone path). Added occupied-pack data to both packets so it correctly tests the with-packs case.
- **Added** `test_standalone_pps_soc_refreshes_on_live_host_packet` — direct reproducer for #43: stale overall packet seeds `soc_percent=100`, live host packet at 82%, assert `soc_percent` follows to 82.

All 8 SOC/ghost-suppression tests pass under stdlib unittest. The pre-existing `pytest`-import errors in `test_protocol.py` are unrelated.

## Test plan

- [ ] Merge + restart `pecron-monitor.service` on stills.
- [ ] `mosquitto_sub -h 127.0.0.1 -t pecron/682499E40D61/state` shows `soc_percent` matching the device's physical display within ~30s.
- [ ] HA's `sensor.pecron_e1500lfp_682499e40d61_battery_soc` tracks live SOC.
- [ ] Drop SOC below 21% and verify `automation.office_ups_charge_threshold_e1500lfp_20_80` fires the plug ON.