### PR TITLE
fix: read-back verify local-control writes (#46)

### DIFF
--- a/local_transport.py
+++ b/local_transport.py
@@ -614,10 +614,27 @@ class LocalTransport:
                 return {}
 
     def send_control(self, data_point_id: int, value, ctrl_type: str = "BOOL") -> bool:
-        """Send a control command over local TCP."""
+        """Send a control command over local TCP and verify it took effect.
+
+        Returns True only when a post-write read-back confirms the data point
+        now reflects the requested value. False indicates the write was sent
+        but the device did not apply it (rejected, watchdog-reset, malformed
+        response, etc.) — see issue #46. When the controls TSL doesn't include
+        the data point, falls back to "best-effort True" with a warning since
+        we have no field name to read back against.
+        """
         if not self.connected:
             return False
 
+        if not self._send_control_packet(data_point_id, value, ctrl_type):
+            return False
+
+        return self._verify_control_write(data_point_id, value, ctrl_type)
+
+    def _send_control_packet(self, data_point_id: int, value, ctrl_type: str) -> bool:
+        """Build and send the TTLV write packet. Returns True if the packet
+        went out and a response was received at the transport level. Does NOT
+        verify the device accepted the write — callers must read back."""
         with self._lock:
             try:
                 ctrl_type = ctrl_type.upper()
@@ -635,13 +652,90 @@ class LocalTransport:
 
                 resp = self._recv_packet()
                 parsed = _ttlv_parse_packet(resp)
-                log.info("Local control response: cmd=0x%04x", parsed.get("cmd", 0))
+                log.info("Local control write response: cmd=0x%04x", parsed.get("cmd", 0))
                 return True
 
             except Exception as e:
-                log.error("Local control failed: %s", e)
+                log.error("Local control send failed: %s", e)
                 self._connected = False
                 return False
+
+    def _verify_control_write(self, data_point_id: int, expected_value, ctrl_type: str) -> bool:
+        """Read back device state and confirm data_point_id reflects expected_value.
+
+        Returns True only when the read-back confirms the write took effect.
+        Falls back to best-effort True (with warning) if the controls TSL has
+        no entry for data_point_id — without a field name we can't index into
+        the read response.
+        """
+        field = self._field_for_data_point(data_point_id)
+        if field is None:
+            log.warning(
+                "data_point_id=%d not in controls map for %s; cannot verify write, "
+                "falling back to best-effort success",
+                data_point_id, self.device_key,
+            )
+            return True
+
+        # Brief settling delay; some firmwares need a moment before reads
+        # reflect a just-written value.
+        time.sleep(0.5)
+
+        try:
+            kv = self.read_status()
+        except Exception as e:
+            log.warning("Read-back after write to %s failed: %s", field, e)
+            return False
+
+        if not kv:
+            log.warning("Read-back after write to %s returned no fields", field)
+            return False
+
+        actual = kv.get(field)
+        if actual is None:
+            log.warning(
+                "Read-back missing field %s; cannot confirm write of value=%r",
+                field, expected_value,
+            )
+            return False
+
+        if not _control_values_equal(expected_value, actual, ctrl_type):
+            log.warning(
+                "Write to %s not confirmed: requested=%r actual=%r; device may have "
+                "rejected the write or watchdog-reset (see issue #46)",
+                field, expected_value, actual,
+            )
+            return False
+
+        log.debug("Write to %s confirmed by read-back: value=%r", field, actual)
+        return True
+
+    def _field_for_data_point(self, data_point_id: int):
+        """Reverse-lookup the TSL code for a data_point_id from self.controls."""
+        if not self.controls:
+            return None
+        for code, info in self.controls.items():
+            try:
+                if info.get("id") == data_point_id:
+                    return code
+            except AttributeError:
+                continue
+        return None
+
+
+def _control_values_equal(expected, actual, ctrl_type: str) -> bool:
+    """Compare a requested control value against what the device reported back.
+
+    BOOL fields come back from `_ttlv_parse_fields` as Python bool; ENUM/INT
+    come back as int (or float when scaled). Normalize both sides before
+    comparing so we don't trip on True vs 1, "1" vs 1, etc.
+    """
+    try:
+        if ctrl_type.upper() == "BOOL":
+            return bool(expected) == bool(actual)
+        return int(actual) == int(expected)
+    except (TypeError, ValueError):
+        return False
 
 
 # ===========================================================================
@@ -971,10 +1065,22 @@ class BLETransport:
                 return {}
 
     def send_control(self, data_point_id: int, value, ctrl_type: str = "BOOL") -> bool:
-        """Send a control command over BLE."""
+        """Send a control command over BLE and verify it took effect.
+
+        Mirrors the read-back-verification model used by `LocalTransport.send_control`
+        (see issue #46). Returns True only when a post-write read confirms the
+        data point now reflects the requested value.
+        """
         if not self.connected:
             return False
 
+        if not self._send_control_packet(data_point_id, value, ctrl_type):
+            return False
+
+        return self._verify_control_write(data_point_id, value, ctrl_type)
+
+    def _send_control_packet(self, data_point_id: int, value, ctrl_type: str) -> bool:
+        """Build and send the TTLV write packet over BLE; collect response."""
         with self._lock:
             try:
                 ctrl_type = ctrl_type.upper()
@@ -995,13 +1101,66 @@ class BLETransport:
 
                 # Collect response (0x7036 ack + 0x0014 confirmation)
                 self._collect_indications(wait=2, extra_wait=2)
-                log.info("BLE control sent: field=%d value=%s", data_point_id, value)
+                log.info("BLE control write sent: field=%d value=%s", data_point_id, value)
                 return True
 
             except Exception as e:
                 log.error("BLE control failed: %s", e)
                 self._connected = False
                 return False
+
+    def _verify_control_write(self, data_point_id: int, expected_value, ctrl_type: str) -> bool:
+        """Read back device state via BLE and confirm data_point_id reflects expected_value."""
+        field = self._field_for_data_point(data_point_id)
+        if field is None:
+            log.warning(
+                "data_point_id=%d not in controls map for %s; cannot verify BLE write, "
+                "falling back to best-effort success",
+                data_point_id, getattr(self, "device_key", "?"),
+            )
+            return True
+
+        time.sleep(0.5)
+
+        try:
+            kv = self.read_status()
+        except Exception as e:
+            log.warning("BLE read-back after write to %s failed: %s", field, e)
+            return False
+
+        if not kv:
+            log.warning("BLE read-back after write to %s returned no fields", field)
+            return False
+
+        actual = kv.get(field)
+        if actual is None:
+            log.warning(
+                "BLE read-back missing field %s; cannot confirm write of value=%r",
+                field, expected_value,
+            )
+            return False
+
+        if not _control_values_equal(expected_value, actual, ctrl_type):
+            log.warning(
+                "BLE write to %s not confirmed: requested=%r actual=%r",
+                field, expected_value, actual,
+            )
+            return False
+
+        log.debug("BLE write to %s confirmed by read-back: value=%r", field, actual)
+        return True
+
+    def _field_for_data_point(self, data_point_id: int):
+        """Reverse-lookup the TSL code for a data_point_id from self.controls."""
+        if not self.controls:
+            return None
+        for code, info in self.controls.items():
+            try:
+                if info.get("id") == data_point_id:
+                    return code
+            except AttributeError:
+                continue
+        return None
 
     def is_alive(self) -> bool:
         """Check if the gatttool process is still running."""

--- a/tests/unit/test_control_readback.py
+++ b/tests/unit/test_control_readback.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Tests for LocalTransport read-back verification (issue #46).
+
+`LocalTransport.send_control` previously reported success regardless of whether
+the device actually applied the write. After the fix it does a post-write
+`read_status` and compares the data point against the requested value, so
+silent failures (rejected writes, watchdog-resets) surface as `False`.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+# sys.path is handled globally by tests/conftest.py
+from local_transport import LocalTransport, _control_values_equal
+
+
+def make_transport(controls=None):
+    """Build a LocalTransport with auth/socket state stubbed for unit testing."""
+    t = LocalTransport(
+        device_ip="192.168.1.99",
+        auth_key_b64="AAAAAAAAAAAAAAAAAAAAAA==",  # 16 zero bytes
+        device_key="DEV1",
+        controls=controls or {},
+    )
+    t._sock = MagicMock()
+    t._iv = b"\x00" * 16
+    t._encrypted = True
+    t._connected = True
+    return t
+
+
+CONTROLS_BOOL = {
+    "dc_switch_hm": {"id": 38, "type": "BOOL", "access": "RW"},
+    "ac_switch_hm": {"id": 40, "type": "BOOL", "access": "RW"},
+}
+
+CONTROLS_ENUM = {
+    "ac_charging_power_ios": {"id": 51, "type": "ENUM", "access": "RW"},
+}
+
+
+class TestSendControlReadback(unittest.TestCase):
+
+    def test_returns_true_when_readback_confirms_bool_write(self):
+        """Standard happy path: device's post-write state matches the request."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock(return_value={"dc_switch_hm": False})
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertTrue(result)
+        t.read_status.assert_called_once()
+
+    def test_returns_false_when_readback_value_mismatches(self):
+        """Device acknowledged the write but didn't actually flip the relay."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=True)
+        # We tried to set False; device still reports True.
+        t.read_status = MagicMock(return_value={"dc_switch_hm": True})
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertFalse(result)
+
+    def test_returns_false_when_readback_returns_empty(self):
+        """Device returned no fields (possibly mid-watchdog-reset)."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock(return_value={})
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertFalse(result)
+
+    def test_returns_false_when_readback_missing_target_field(self):
+        """Read came back populated but doesn't include the data point we wrote."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock(return_value={"voltage": 52.4, "soc_percent": 73})
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertFalse(result)
+
+    def test_returns_false_when_readback_raises(self):
+        """TCP read-back failed (e.g. connection drop after device reset)."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock(side_effect=ConnectionError("device reset mid-stream"))
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertFalse(result)
+
+    def test_returns_true_with_warning_when_controls_empty(self):
+        """No TSL means we can't index a read response; preserve pre-fix behavior
+        rather than regress callers that don't pass controls."""
+        t = make_transport(controls={})
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock()
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertTrue(result)
+        t.read_status.assert_not_called()
+
+    def test_returns_true_when_data_point_not_in_controls(self):
+        """Controls populated but no entry matches data_point_id; same fallback."""
+        t = make_transport(CONTROLS_BOOL)  # only ids 38/40
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock()
+
+        result = t.send_control(data_point_id=99, value=False, ctrl_type="BOOL")
+
+        self.assertTrue(result)
+        t.read_status.assert_not_called()
+
+    def test_returns_false_when_packet_send_fails(self):
+        """Transport-level write failure short-circuits before read-back."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=False)
+        t.read_status = MagicMock()
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertFalse(result)
+        t.read_status.assert_not_called()
+
+    def test_enum_write_readback_int_compare(self):
+        """ENUM/INT values normalize through int() on both sides."""
+        t = make_transport(CONTROLS_ENUM)
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock(return_value={"ac_charging_power_ios": 2})
+
+        result = t.send_control(data_point_id=51, value=2, ctrl_type="ENUM")
+
+        self.assertTrue(result)
+
+    def test_enum_write_readback_mismatch(self):
+        t = make_transport(CONTROLS_ENUM)
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock(return_value={"ac_charging_power_ios": 5})
+
+        result = t.send_control(data_point_id=51, value=2, ctrl_type="ENUM")
+
+        self.assertFalse(result)
+
+    def test_disconnected_transport_short_circuits(self):
+        t = make_transport(CONTROLS_BOOL)
+        t._connected = False  # disconnected
+        t._send_control_packet = MagicMock()
+        t.read_status = MagicMock()
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertFalse(result)
+        t._send_control_packet.assert_not_called()
+        t.read_status.assert_not_called()
+
+
+class TestControlValuesEqual(unittest.TestCase):
+
+    def test_bool_true_matches_true(self):
+        self.assertTrue(_control_values_equal(True, True, "BOOL"))
+
+    def test_bool_false_matches_false(self):
+        self.assertTrue(_control_values_equal(False, False, "BOOL"))
+
+    def test_bool_true_matches_int_one(self):
+        """Pecron parser yields bool, but be defensive about 0/1 ints too."""
+        self.assertTrue(_control_values_equal(True, 1, "BOOL"))
+        self.assertTrue(_control_values_equal(1, True, "BOOL"))
+
+    def test_bool_mismatch(self):
+        self.assertFalse(_control_values_equal(True, False, "BOOL"))
+        self.assertFalse(_control_values_equal(False, True, "BOOL"))
+
+    def test_int_match(self):
+        self.assertTrue(_control_values_equal(5, 5, "ENUM"))
+        self.assertTrue(_control_values_equal(0, 0, "INT"))
+
+    def test_int_mismatch(self):
+        self.assertFalse(_control_values_equal(5, 4, "ENUM"))
+
+    def test_unparseable_returns_false(self):
+        self.assertFalse(_control_values_equal("not-a-number", 5, "INT"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #46.

## Summary

Before this change, `LocalTransport.send_control` (and the BLE equivalent) sent the TTLV write packet, read whatever response came back, logged the cmd byte, and **always returned True**. There was no validation that the device actually applied the write. The 2026-04-30 incident on the E1500LFP — HA toggled `dc_switch_hm=False`, the unit watchdog-reset itself, HA saw "success" — landed because of this.

## Fix

Split `send_control` into:

- `_send_control_packet` — builds and sends the TTLV write, gets a transport-level response.
- `_verify_control_write` — reads the device's current state via `read_status` and compares the data point against the requested value.

`send_control` returns True only when both the send succeeds and the read-back confirms the data point now reflects the requested value. False covers: write failed at transport level, read-back returned empty, read-back missing the target field, value mismatch, or read-back raised (TCP drop after device reset).

When the `controls` TSL doesn't include the written `data_point_id`, falls back to best-effort True with a warning — preserves pre-fix behavior for callers that don't populate controls so this isn't a silent regression.

Same model applied to `BLETransport.send_control` since it had the identical bug.

## Why read-back instead of just validating the response cmd

We don't have a definitive list of which response cmd codes mean "write successful" vs "write rejected" for Pecron firmware (and as #46 noted, observed responses include 0x0014 data dumps which don't fit a clean ACK pattern). Read-back sidesteps that uncertainty entirely: whatever the device's response convention, the only authoritative confirmation is "the data point now holds the value I asked for." Naturally catches the watchdog-reset case too — the connection drops, `read_status` raises, we return False.

## Tests

New `tests/unit/test_control_readback.py` (18 tests):

- `test_returns_true_when_readback_confirms_bool_write` — happy path
- `test_returns_false_when_readback_value_mismatches` — direct repro of the #46 incident pattern
- `test_returns_false_when_readback_returns_empty` — device unresponsive post-write
- `test_returns_false_when_readback_missing_target_field` — read populated but missing the field
- `test_returns_false_when_readback_raises` — TCP drop after device reset
- `test_returns_true_with_warning_when_controls_empty` — backward-compat fallback
- `test_returns_true_when_data_point_not_in_controls` — same fallback
- `test_returns_false_when_packet_send_fails` — short-circuit before read-back
- `test_enum_write_readback_int_compare` + `test_enum_write_readback_mismatch` — non-bool path
- `test_disconnected_transport_short_circuits` — pre-flight check
- 7 tests for `_control_values_equal` covering bool/int normalization and unparseable inputs

All 18 pass. Existing 54 stdlib-unittest tests continue to pass; the 2 errors in the full suite are pre-existing `pytest`-import issues in `test_protocol.py` unrelated to this change.

## Caveats

- Adds a 0.5s settling delay before read-back (some firmwares need a moment for newly-written values to be reflected). Configurable as a follow-up if anyone hits a use case where this matters.
- BLE path follows the same model but the BLE `read_status` performance hasn't been validated under read-back load — could land a follow-up if turnaround proves too slow.
- After deploy, callers in `monitor.py` that previously got True regardless will start getting False on real failures. They currently log a warning and fall through to other transports (BLE → TCP → cloud); now those fallbacks will actually get exercised when the primary write didn't take. This is the desired behavior, but worth knowing.

## Test plan

- [ ] Merge + restart `pecron-monitor` on stills (`sudo systemctl restart pecron-monitor`).
- [ ] In HA, toggle `switch.pecron_e1500lfp_682499e40d61_ac_switch` (a switch we haven't tried — AC-side, may behave fine where DC didn't). Verify HA's optimistic state matches what the device actually does. If verification fails, HA should revert.
- [ ] Re-attempt the DC switch toggle that originally surfaced #46 — expect either (a) it now works because the path is more robust, or (b) it still resets the device but HA now correctly reports failure. Either is an improvement; case (b) confirms the device-side bug as a separate follow-up.