### PR TITLE
feat: add verify=False opt-out for transient control writes (#50)

### DIFF
--- a/local_transport.py
+++ b/local_transport.py
@@ -613,21 +613,30 @@ class LocalTransport:
                 self._connected = False
                 return {}
 
-    def send_control(self, data_point_id: int, value, ctrl_type: str = "BOOL") -> bool:
-        """Send a control command over local TCP and verify it took effect.
+    def send_control(self, data_point_id: int, value, ctrl_type: str = "BOOL", verify: bool = True) -> bool:
+        """Send a control command over local TCP and (by default) verify it took effect.
 
         Returns True only when a post-write read-back confirms the data point
         now reflects the requested value. False indicates the write was sent
         but the device did not apply it (rejected, watchdog-reset, malformed
-        response, etc.) — see issue #46. When the controls TSL doesn't include
+        response, etc.) -- see issue #46. When the controls TSL doesn't include
         the data point, falls back to "best-effort True" with a warning since
         we have no field name to read back against.
+
+        Pass `verify=False` for transient control codes that the device
+        intentionally auto-reverts (e.g. `high_frequency_reporting`, see
+        issue #50). With verification disabled this skips the post-write
+        read-back and returns whatever `_send_control_packet` returned.
         """
         if not self.connected:
             return False
 
-        if not self._send_control_packet(data_point_id, value, ctrl_type):
+        sent = self._send_control_packet(data_point_id, value, ctrl_type)
+        if not sent:
             return False
+
+        if not verify:
+            return sent
 
         return self._verify_control_write(data_point_id, value, ctrl_type)
 
@@ -1064,18 +1073,27 @@ class BLETransport:
                 self._connected = False
                 return {}
 
-    def send_control(self, data_point_id: int, value, ctrl_type: str = "BOOL") -> bool:
-        """Send a control command over BLE and verify it took effect.
+    def send_control(self, data_point_id: int, value, ctrl_type: str = "BOOL", verify: bool = True) -> bool:
+        """Send a control command over BLE and (by default) verify it took effect.
 
         Mirrors the read-back-verification model used by `LocalTransport.send_control`
         (see issue #46). Returns True only when a post-write read confirms the
         data point now reflects the requested value.
+
+        Pass `verify=False` for transient control codes that the device
+        intentionally auto-reverts (see issue #50). With verification disabled
+        this skips the post-write read-back and returns whatever
+        `_send_control_packet` returned.
         """
         if not self.connected:
             return False
 
-        if not self._send_control_packet(data_point_id, value, ctrl_type):
+        sent = self._send_control_packet(data_point_id, value, ctrl_type)
+        if not sent:
             return False
+
+        if not verify:
+            return sent
 
         return self._verify_control_write(data_point_id, value, ctrl_type)
 

--- a/monitor.py
+++ b/monitor.py
@@ -759,8 +759,16 @@ class PecronMonitor:
 
     # --- Control commands ---
 
-    def send_control(self, device_key: str, control_code: str, value):
-        """Send a control command. Auto-detects type from TSL (BOOL, ENUM, INT)."""
+    def send_control(self, device_key: str, control_code: str, value, verify: bool = True):
+        """Send a control command. Auto-detects type from TSL (BOOL, ENUM, INT).
+
+        `verify=True` (default) asks the local/BLE transport to read the data
+        point back and confirm the device applied the write (issue #46). Pass
+        `verify=False` for transient control codes that the device intentionally
+        auto-reverts (e.g. `high_frequency_reporting`, see issue #50) so the
+        read-back doesn't spuriously log a mismatch warning. Cloud-only
+        transports (MQTT/REST) are unaffected -- they have no read-back step.
+        """
         device = self._find_device(device_key)
         if not device:
             log.error("Device %s not found", device_key)
@@ -793,7 +801,7 @@ class PecronMonitor:
         ble = self.ble_transports.get(device_key)
         if ble and ble.connected:
             try:
-                if ble.send_control(ctrl["id"], value, ctrl_type):
+                if ble.send_control(ctrl["id"], value, ctrl_type, verify=verify):
                     log.info("Sent %s=%s (type=%s) to %s via BLE", control_code, value, ctrl_type, device_key)
                     return True
             except Exception as e:
@@ -809,7 +817,7 @@ class PecronMonitor:
                     log.debug("Local TCP reconnect failed for %s: %s", device_key, e)
             if lt.connected:
                 try:
-                    if lt.send_control(ctrl["id"], value, ctrl_type):
+                    if lt.send_control(ctrl["id"], value, ctrl_type, verify=verify):
                         log.info("Sent %s=%s (type=%s) to %s via TCP", control_code, value, ctrl_type, device_key)
                         return True
                 except Exception as e:
@@ -1348,7 +1356,10 @@ class PecronMonitor:
         for i, d in enumerate(effective):
             dk = d["device_key"]
             try:
-                self.send_control(dk, "high_frequency_reporting", 3)
+                # high_frequency_reporting is transient: device auto-reverts the
+                # value so a post-write read-back will mismatch and log a noisy
+                # but meaningless warning (issue #50). Skip verification here.
+                self.send_control(dk, "high_frequency_reporting", 3, verify=False)
                 log.info("Enabled high-freq reporting for %s", dk)
             except Exception as e:
                 log.debug("Could not enable high-freq for %s: %s", dk, e)
@@ -1362,7 +1373,8 @@ class PecronMonitor:
                 continue  # never enabled → nothing to disable
             dk = d["device_key"]
             try:
-                self.send_control(dk, "high_frequency_reporting", 0)
+                # Transient control code; suppress read-back verification (#50).
+                self.send_control(dk, "high_frequency_reporting", 0, verify=False)
                 log.info("Disabled high-freq reporting for %s (warm-up complete)", dk)
             except Exception as e:
                 log.debug("Could not disable high-freq for %s: %s", dk, e)

--- a/tests/unit/test_control_readback.py
+++ b/tests/unit/test_control_readback.py
@@ -159,6 +159,48 @@ class TestSendControlReadback(unittest.TestCase):
         t.read_status.assert_not_called()
 
 
+class TestVerifyOptOut(unittest.TestCase):
+    """`verify=False` skips the post-write read-back for transient control codes
+    that the device intentionally auto-reverts (e.g. `high_frequency_reporting`,
+    see issue #50)."""
+
+    def test_verify_false_skips_readback(self):
+        """`verify=False` returns whatever `_send_control_packet` returned and
+        never calls `read_status` -- no spurious mismatch warning."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock()
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL", verify=False)
+
+        self.assertTrue(result)
+        t._send_control_packet.assert_called_once_with(38, False, "BOOL")
+        t.read_status.assert_not_called()
+
+    def test_verify_false_returns_send_packet_failure(self):
+        """`verify=False` still surfaces transport-level send failures."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=False)
+        t.read_status = MagicMock()
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL", verify=False)
+
+        self.assertFalse(result)
+        t.read_status.assert_not_called()
+
+    def test_verify_true_default_calls_readback(self):
+        """Default behavior (no kwarg) still verifies via read-back -- backward
+        compatible with pre-#50 callers."""
+        t = make_transport(CONTROLS_BOOL)
+        t._send_control_packet = MagicMock(return_value=True)
+        t.read_status = MagicMock(return_value={"dc_switch_hm": False})
+
+        result = t.send_control(data_point_id=38, value=False, ctrl_type="BOOL")
+
+        self.assertTrue(result)
+        t.read_status.assert_called_once()
+
+
 class TestControlValuesEqual(unittest.TestCase):
 
     def test_bool_true_matches_true(self):

--- a/tests/unit/test_model_behavior.py
+++ b/tests/unit/test_model_behavior.py
@@ -44,7 +44,10 @@ class TestModelBehavior(unittest.TestCase):
     def test_enable_sends_for_e3800(self):
         m = make_monitor(["E3800LFP"])
         m._enable_high_freq_reporting()
-        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 3)
+        # high_frequency_reporting is transient -- the device auto-reverts the
+        # value, so the warm-up callers pass verify=False to skip the noisy
+        # post-write read-back (issue #50).
+        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 3, verify=False)
 
     def test_mixed_fleet_sends_only_for_effective_models(self):
         """A mixed config should send for E3800LFP and skip E3600LFP."""
@@ -62,13 +65,15 @@ class TestModelBehavior(unittest.TestCase):
     def test_disable_sends_for_e3800(self):
         m = make_monitor(["E3800LFP"])
         m._disable_high_freq_reporting()
-        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 0)
+        # See test_enable_sends_for_e3800 -- verify=False on transient writes (#50).
+        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 0, verify=False)
 
     def test_unknown_model_defaults_to_effective(self):
         """Baseline (unlisted models) keeps current behavior: send the setting."""
         m = make_monitor(["SomeNewModel"])
         m._enable_high_freq_reporting()
-        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 3)
+        # See test_enable_sends_for_e3800 -- verify=False on transient writes (#50).
+        m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 3, verify=False)
 
 
 class TestE3600Capacity(unittest.TestCase):


### PR DESCRIPTION
## Summary

PR #47 (commit `0baac7c`) added unconditional read-back verification to `LocalTransport.send_control` and `BLETransport.send_control` to catch writes that the device silently rejected (issue #46). That works well for persistent control codes (output switches, eco mode, settings).

It is, however, noisy for **transient** codes that the device intentionally auto-reverts. The internal `high_frequency_reporting` writes pecron-monitor does at startup (set to 3 for warm-up, set to 0 after) trip this every restart -- the device reverts the value before the 0.5s read-back samples it, so we now get:

```
19:13:38 INFO  Local control write response: cmd=0x7036
19:13:43 WARN  Write to high_frequency_reporting not confirmed: requested=3 actual=0 ...
19:13:43 INFO  Sent high_frequency_reporting=3 (type=ENUM) to ... via CLOUD MQTT
```

Functionally fine (cloud MQTT fallback succeeds, warm-up works) but misleading WARN noise.

## Changes

- `LocalTransport.send_control` and `BLETransport.send_control` gain a `verify: bool = True` keyword. When `verify=False`, skip `_verify_control_write` and return whatever `_send_control_packet` returned. Default stays `True` -- backward-compatible with every existing caller.
- `PecronMonitor.send_control` gains a matching `verify: bool = True` kwarg and forwards it to the transport.
- `_enable_high_freq_reporting` and `_disable_high_freq_reporting` in `monitor.py` opt out via `verify=False` -- they're the only known transient-code callers today.

Cloud-only paths (MQTT/REST) are unaffected; they have no read-back step to begin with.

## Test plan

- [x] `python3 -m unittest tests.unit.test_control_readback -v` -- 21 tests OK (18 pre-existing + 3 new):
  - `test_verify_false_skips_readback` -- `verify=False` returns `_send_control_packet`'s result and never calls `read_status`.
  - `test_verify_false_returns_send_packet_failure` -- `verify=False` still surfaces transport-level send failures.
  - `test_verify_true_default_calls_readback` -- omitting the kwarg preserves the default read-back path (backward-compat guarantee).
- [x] `python3 -m unittest discover tests/unit` -- 73 tests OK (was 70 + 3 new). `test_model_behavior.py` assertions for the `high_frequency_reporting` warm-up calls were updated to expect the new `verify=False` kwarg.
- [x] No regression in the broader suite. The two pre-existing pytest-import errors in `test_protocol.py` and `test_total_power_fallback.py` are not regressions and are unaffected by this change.

Closes #50.