### PR TITLE
fix: refresh total_input/output_power on standalone PPS (#48)

### DIFF
--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -985,10 +985,20 @@ class HomeAssistantBridge:
             except (TypeError, ValueError):
                 pass
 
+        # Track whether the top-level total fields were present AND accepted
+        # in *this* packet (vs only carried over from the cache). The aggregate
+        # fallback at the end of publish_state needs this so it can preserve a
+        # canonical top-level reading received in this packet on standalone PPS
+        # devices, while still re-aggregating when the top-level was absent or
+        # was suppressed by the host-zero guard. See issue #48.
+        total_input_top_level_used = False
+        total_output_top_level_used = False
+
         present, v = _get_first_present(SENSOR_FIELDS["total_input_power"])
         if present and (not packet_has_host or float(v) != 0.0):
             try:
                 cache["total_input_power"] = int(float(v))
+                total_input_top_level_used = True
             except (TypeError, ValueError):
                 pass
 
@@ -996,6 +1006,7 @@ class HomeAssistantBridge:
         if present and (not packet_has_host or float(v) != 0.0):
             try:
                 cache["total_output_power"] = int(float(v))
+                total_output_top_level_used = True
             except (TypeError, ValueError):
                 pass
 
@@ -1232,17 +1243,39 @@ class HomeAssistantBridge:
         # Parallels the same fallback already done in monitor._process_data for
         # the status log. Runs AFTER all components are cached so it sees
         # whatever landed in this or any earlier packet.
-        if cache.get("total_input_power") is None:
-            ac_in = cache.get("ac_input_power")
-            dc_in = cache.get("dc_input_power")
-            if ac_in is not None and dc_in is not None:
-                cache["total_input_power"] = int(ac_in + dc_in)
+        #
+        # Issue #48: on standalone PPS (no occupied expansion packs) the same
+        # "fill once, never refresh" pattern that #43 hit for soc_percent also
+        # hits the totals. The host-zero guard above on total_input_power /
+        # total_output_power skips the 0 reading on host packets, so when AC
+        # is unplugged the cached value stays non-zero (e.g. 1329W) forever
+        # while ac_input_power and dc_input_power correctly read 0; the old
+        # `if total is None` fallback never re-runs because the cache is
+        # already populated. Detect standalone the same way #44 did (no
+        # pack_*_status set) and re-aggregate from components for those
+        # devices when the top-level total was NOT explicitly accepted from
+        # this packet (i.e. either absent or suppressed by the host-zero
+        # guard). If the device DID send a real top-level total this packet,
+        # respect it -- some models include components other than ac+dc in
+        # their top-level reading. Devices with packs preserve the original
+        # "fill once, never refresh" behavior unconditionally.
+        is_standalone = not any(cache.get(f"pack_{i}_status") for i in range(4))
 
-        if cache.get("total_output_power") is None:
-            ac_out = cache.get("ac_output_power")
-            dc_out = cache.get("dc_output_power")
-            if ac_out is not None and dc_out is not None:
-                cache["total_output_power"] = int(ac_out + dc_out)
+        ac_in = cache.get("ac_input_power")
+        dc_in = cache.get("dc_input_power")
+        should_aggregate_input = cache.get("total_input_power") is None or (
+            is_standalone and not total_input_top_level_used
+        )
+        if should_aggregate_input and ac_in is not None and dc_in is not None:
+            cache["total_input_power"] = int(ac_in + dc_in)
+
+        ac_out = cache.get("ac_output_power")
+        dc_out = cache.get("dc_output_power")
+        should_aggregate_output = cache.get("total_output_power") is None or (
+            is_standalone and not total_output_top_level_used
+        )
+        if should_aggregate_output and ac_out is not None and dc_out is not None:
+            cache["total_output_power"] = int(ac_out + dc_out)
 
         # ---- SOC vs Host % ----
         # Your device alternates two payload shapes:

--- a/tests/unit/test_ghost_suppression.py
+++ b/tests/unit/test_ghost_suppression.py
@@ -282,5 +282,150 @@ class TestSocFallback(unittest.TestCase):
                          "on live host packets even after a prior overall packet")
 
 
+# -------------------- Total power fallback (issue #48) --------------------
+
+
+class TestTotalPowerFallback(unittest.TestCase):
+    """Issue #48: same one-time-fill pattern as #43 but for total_input_power /
+    total_output_power. The host-zero guard on the top-level total fields keeps
+    a stale non-zero cached value when AC drops; the aggregate fallback never
+    re-runs because the cached value is no longer None. Standalone PPS must
+    re-aggregate from components on every packet so the published JSON tracks
+    the live state. Devices with occupied packs preserve the original
+    "fill once, don't clobber" behavior."""
+
+    def test_standalone_pps_total_input_power_refreshes(self):
+        """Stale cached total_input_power must drop to 0 on a standalone PPS
+        when ac_input_power and dc_input_power both read 0 in a live packet."""
+        b = make_bridge()
+
+        # Step 1: live host packet with ac/dc input populated. The aggregate
+        # fallback fills total_input_power=1500 (= 1200 + 300). Per-source
+        # paths are nested under ac_data_input_hm / dc_data_input_hm to match
+        # the live MQTT shape (see constants.SENSOR_FIELDS).
+        kv_initial = {
+            "host_packet_data_jdb": {
+                "host_packet_voltage": 53.1,
+                "host_packet_electric_percentage": 95,
+            },
+            "ac_data_input_hm": {"ac_input_power": 1200},
+            "dc_data_input_hm": {"dc_input_power": 300},
+        }
+        b.publish_state("DEV1", kv_initial)
+        cache = b._state_cache["DEV1"]
+        self.assertEqual(cache.get("total_input_power"), 1500,
+                         "initial aggregate should populate total_input_power")
+
+        # Step 2: AC drops, live host packet shows ac_input=0 and dc_input=0.
+        # On a standalone PPS the cached total must be re-aggregated to 0
+        # instead of holding the stale 1500 forever (which is what bug #48
+        # produced before this fix).
+        kv_ac_dropped = {
+            "host_packet_data_jdb": {
+                "host_packet_voltage": 53.1,
+                "host_packet_electric_percentage": 95,
+            },
+            "ac_data_input_hm": {"ac_input_power": 0},
+            "dc_data_input_hm": {"dc_input_power": 0},
+        }
+        b.publish_state("DEV1", kv_ac_dropped)
+        cache = b._state_cache["DEV1"]
+        self.assertEqual(cache.get("ac_input_power"), 0)
+        self.assertEqual(cache.get("dc_input_power"), 0)
+        self.assertEqual(cache.get("total_input_power"), 0,
+                         "standalone PPS total_input_power must refresh to 0 "
+                         "when ac_input_power and dc_input_power both drop to 0")
+
+    def test_standalone_pps_total_output_power_refreshes(self):
+        """Same pattern for the output side: stale cached total_output_power
+        must follow live ac_output_power + dc_output_power on standalone PPS."""
+        b = make_bridge()
+
+        kv_initial = {
+            "host_packet_data_jdb": {
+                "host_packet_voltage": 53.1,
+                "host_packet_electric_percentage": 95,
+            },
+            "ac_data_output_hm": {"ac_output_power": 800},
+            "dc_data_output_hm": {"dc_output_power": 200},
+        }
+        b.publish_state("DEV1", kv_initial)
+        cache = b._state_cache["DEV1"]
+        self.assertEqual(cache.get("total_output_power"), 1000,
+                         "initial aggregate should populate total_output_power")
+
+        kv_load_dropped = {
+            "host_packet_data_jdb": {
+                "host_packet_voltage": 53.1,
+                "host_packet_electric_percentage": 95,
+            },
+            "ac_data_output_hm": {"ac_output_power": 0},
+            "dc_data_output_hm": {"dc_output_power": 0},
+        }
+        b.publish_state("DEV1", kv_load_dropped)
+        cache = b._state_cache["DEV1"]
+        self.assertEqual(cache.get("ac_output_power"), 0)
+        self.assertEqual(cache.get("dc_output_power"), 0)
+        self.assertEqual(cache.get("total_output_power"), 0,
+                         "standalone PPS total_output_power must refresh to 0 "
+                         "when ac_output_power and dc_output_power both drop to 0")
+
+    def test_total_power_not_clobbered_with_packs(self):
+        """Devices with at least one occupied expansion pack must preserve
+        the original 'fill once, don't clobber' behavior: a cached
+        total_input_power must NOT be re-aggregated from components on
+        subsequent packets, since the canonical top-level total reading is
+        authoritative for those models."""
+        b = make_bridge()
+
+        connected_pack = {
+            "charging_pack_status": 3,  # balanced charging
+            "charging_pack_battery": 80,
+            "charging_pack_voltage": 53.0,
+            "charging_pack_current": 1.2,
+            "charging_pack_temp": 28,
+        }
+
+        # First packet: top-level total_input_power is the canonical reading
+        # for this model. Pack data marks it as non-standalone (one occupied
+        # pack is enough to disable the standalone re-aggregation path).
+        kv_with_total = {
+            "battery_percentage": 85,
+            "total_input_power": 1500,
+            "ac_data_input_hm": {"ac_input_power": 1200},
+            "dc_data_input_hm": {"dc_input_power": 300},
+            "charging_pack_data_jdb": [
+                connected_pack,
+                {"charging_pack_status": 4},
+                {"charging_pack_status": 4},
+                {"charging_pack_status": 4},
+            ],
+        }
+        b.publish_state("DEV1", kv_with_total)
+        cache = b._state_cache["DEV1"]
+        self.assertEqual(cache.get("total_input_power"), 1500,
+                         "initial top-level total_input_power should populate cache")
+
+        # Second packet: same pack still occupied, ac/dc drop to 0 but the
+        # top-level total isn't re-emitted in this packet. The cached value
+        # must NOT be re-aggregated from components (would clobber 1500 with 0).
+        kv_packet_two = {
+            "battery_percentage": 85,
+            "ac_data_input_hm": {"ac_input_power": 0},
+            "dc_data_input_hm": {"dc_input_power": 0},
+            "charging_pack_data_jdb": [
+                connected_pack,
+                {"charging_pack_status": 4},
+                {"charging_pack_status": 4},
+                {"charging_pack_status": 4},
+            ],
+        }
+        b.publish_state("DEV1", kv_packet_two)
+        cache = b._state_cache["DEV1"]
+        self.assertEqual(cache.get("total_input_power"), 1500,
+                         "cached total_input_power must not be re-aggregated "
+                         "on devices with occupied expansion packs")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Closes #48.

`ha_bridge.publish_state` had a per-device `_state_cache` that retained `total_input_power` and `total_output_power` across packets. After AC input dropped on a standalone PPS (E1500LFP), live observation showed `ac_input_power=0, dc_input_power=0, total_input_power=1329` in the published JSON while the CLI log correctly read `In:0W`.

Two compounding bugs surfaced this. The host-zero guard on the top-level total fields skipped the 0 reading from host packets, leaving the cached value stale at its last non-zero number. The aggregate-fallback at the end of `publish_state` only ran when `cache.get("total_input_power") is None`, so once filled it never refreshed -- the same "fill once, never refresh" pattern that #43 had for `soc_percent`.

This PR fixes the aggregate-fallback half (bug #2) using the same `is_standalone` detection PR #44 used for the SOC fix. The host-zero guard (bug #1) is intentionally untouched -- that needs packet-trace evidence we don't have yet.

- `is_standalone` is true when no `pack_*_status` is set in cache (no occupied expansion packs)
- On standalone PPS, re-aggregate `total_input_power = ac_input_power + dc_input_power` (and analogous for output) on every packet, so 0s flow through
- BUT preserve the canonical top-level reading when this packet actually carried one: track `total_input_top_level_used` / `total_output_top_level_used` and skip re-aggregation when it was accepted in this packet, so models whose top-level total includes components beyond ac+dc keep working
- Devices with occupied expansion packs preserve the original "fill once, never refresh" behavior unchanged

## Test plan

- [x] `python3 -m unittest tests.unit.test_ghost_suppression -v` passes (11 tests, 3 new under `TestTotalPowerFallback`):
  - `test_standalone_pps_total_input_power_refreshes` -- stale total_input_power=1500 drops to 0 after live ac/dc=0 packet
  - `test_standalone_pps_total_output_power_refreshes` -- same pattern for total_output_power
  - `test_total_power_not_clobbered_with_packs` -- device with occupied pack preserves cached total when top-level absent in next packet
- [x] `python3 -m unittest discover tests/unit` passes (73 tests, OK -- existing `test_top_level_totals_present_overrides_fallback` still passes thanks to the top-level-used flag)
- [ ] Live verification on the affected device after deploy: pull plug, confirm published `total_input_power` follows ac/dc components to 0