### PR TITLE
fix: extend _ha_command slug->TSL map to all discovered switches (#54)

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -1380,11 +1380,33 @@ class PecronMonitor:
                 log.debug("Could not disable high-freq for %s: %s", dk, e)
 
     def _ha_command(self, device_key: str, control: str, on: bool):
-        """Handle commands from Home Assistant."""
-        ctrl_map = {"ac": "ac_switch_hm", "dc": "dc_switch_hm", "ups": "ups_status_hm"}
+        """Handle commands from Home Assistant.
+
+        The slug→TSL map below must mirror every switch published by
+        ha_bridge._publish_discovery with a command_topic. If discovery adds
+        a new switch, add the slug→TSL row here too. Issue #54: previously
+        only ac/dc/ups were mapped, so HA toggles for eco_mode, touch_lock,
+        and auto_dim (auto_light_flag_as) were silently dropped. The longer
+        term cleanup is to drive this map from discovery; not in this PR.
+        """
+        ctrl_map = {
+            "ac": "ac_switch_hm",
+            "dc": "dc_switch_hm",
+            "ups": "ups_status_hm",
+            "eco_mode": "eco_quite_mode_as",
+            "touch_lock": "device_touch_locking_as",
+            # auto_dim's command_topic uses the TSL field name directly
+            # (see ha_bridge.py:628), so the slug == the TSL code here.
+            "auto_light_flag_as": "auto_light_flag_as",
+        }
         code = ctrl_map.get(control)
         if code:
             self.send_bool_control(device_key, code, on)
+        else:
+            log.warning(
+                "HA command for unknown control %r on %s -- no slug->TSL mapping (issue #54)",
+                control, device_key,
+            )
 
     def one_shot_command(self, ac=None, dc=None, force_offline=False):
         """Connect, send a command, verify, and exit."""

--- a/tests/unit/test_ha_command_dispatch.py
+++ b/tests/unit/test_ha_command_dispatch.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Tests for issue #54: PecronMonitor._ha_command must dispatch every slug
+that ha_bridge._publish_discovery advertises with a command_topic.
+
+Issue #49 (PR #51) wired up the subscribe side: every command_topic registered
+in discovery is now subscribed. But the dispatch side (_ha_command in
+monitor.py) still hardcoded {ac, dc, ups}, so commands for eco_mode,
+touch_lock, and auto_light_flag_as (auto_dim) were silently dropped at the
+last hop -- HA toggle UI looked live but nothing reached the device.
+
+The fix extends ctrl_map to mirror every command_topic from discovery, plus
+adds a defense-in-depth WARN log when an unknown control arrives so a future
+discovery addition that misses this map fails loudly instead of silently.
+"""
+
+import base64
+import logging
+import unittest
+from unittest.mock import MagicMock
+
+# sys.path + paho mocking are handled globally by tests/conftest.py
+from monitor import PecronMonitor
+
+FAKE_AUTH = base64.b64encode(b"0123456789abcdef").decode()
+
+
+def make_monitor():
+    """Build a PecronMonitor with mocked send_bool_control.
+
+    Mirrors the make_monitor pattern from test_model_behavior.py but mocks
+    send_bool_control specifically (the method _ha_command actually calls)
+    rather than send_control, so the test asserts on the dispatch path one
+    layer up.
+    """
+    config = {
+        "email": "x", "password": "x", "region": "na",
+        "devices": [{"product_key": "pk", "device_key": "dk0", "name": "E3800",
+                     "lan_ip": "10.0.0.1", "auth_key": FAKE_AUTH}],
+    }
+    m = PecronMonitor(config)
+    m.devices = [{"product_key": "pk", "device_key": "dk0",
+                  "device_name": "E3800", "product_name": "E3800",
+                  "controls": {}}]
+    m.send_bool_control = MagicMock()
+    return m
+
+
+# Slug -> TSL field, sourced from ha_bridge._publish_discovery command_topic
+# registrations and confirmed against constants.E3800_FULL_TSL (all six are
+# BOOL/RW). Keep this aligned with monitor._ha_command.ctrl_map.
+SLUG_TSL_PAIRS = [
+    ("ac", "ac_switch_hm"),
+    ("dc", "dc_switch_hm"),
+    ("ups", "ups_status_hm"),
+    ("eco_mode", "eco_quite_mode_as"),
+    ("touch_lock", "device_touch_locking_as"),
+    ("auto_light_flag_as", "auto_light_flag_as"),
+]
+
+
+class TestHaCommandDispatch(unittest.TestCase):
+    """Issue #54: every discovered slug must dispatch to the right TSL code."""
+
+    def test_each_slug_dispatches_on(self):
+        for slug, tsl_code in SLUG_TSL_PAIRS:
+            with self.subTest(slug=slug):
+                m = make_monitor()
+                m._ha_command("dk0", slug, True)
+                m.send_bool_control.assert_called_once_with("dk0", tsl_code, True)
+
+    def test_each_slug_dispatches_off(self):
+        for slug, tsl_code in SLUG_TSL_PAIRS:
+            with self.subTest(slug=slug):
+                m = make_monitor()
+                m._ha_command("dk0", slug, False)
+                m.send_bool_control.assert_called_once_with("dk0", tsl_code, False)
+
+    def test_unknown_slug_is_dropped_and_warns(self):
+        """Defense-in-depth: an unrecognized control must NOT call
+        send_bool_control AND must emit a WARN log so the gap is visible
+        in production rather than silent."""
+        m = make_monitor()
+        with self.assertLogs("pecron", level="WARNING") as cm:
+            m._ha_command("dk0", "made_up_thing", True)
+        m.send_bool_control.assert_not_called()
+        # Match on the salient bits rather than the exact phrasing so
+        # message tweaks don't break the test.
+        joined = "\n".join(cm.output)
+        self.assertIn("made_up_thing", joined)
+        self.assertIn("dk0", joined)
+        self.assertIn("#54", joined)
+
+    def test_known_slug_does_not_warn(self):
+        """The happy path must stay quiet -- WARN-on-unknown is only for the
+        defense-in-depth case."""
+        m = make_monitor()
+        # assertNoLogs is 3.10+; use a manual handler capture to stay
+        # compatible with whatever the project's minimum is.
+        records = []
+        handler = logging.Handler()
+        handler.setLevel(logging.WARNING)
+        handler.emit = records.append
+        logger = logging.getLogger("pecron")
+        logger.addHandler(handler)
+        try:
+            m._ha_command("dk0", "ac", True)
+        finally:
+            logger.removeHandler(handler)
+        warn_records = [r for r in records if r.levelno >= logging.WARNING
+                        and "#54" in r.getMessage()]
+        self.assertEqual(warn_records, [],
+                         f"unexpected WARN on known slug: {[r.getMessage() for r in warn_records]}")
+        m.send_bool_control.assert_called_once_with("dk0", "ac_switch_hm", True)
+
+
+class TestHaCommandMapMatchesDiscovery(unittest.TestCase):
+    """Regression guard: the dispatch map must cover every command_topic that
+    ha_bridge._publish_discovery advertises. If someone adds a switch to
+    discovery without updating _ha_command, this test fails.
+    """
+
+    def test_every_discovery_command_topic_has_a_dispatch_entry(self):
+        from ha_bridge import HomeAssistantBridge
+
+        # E3800-shaped device with the TSL controls that gate the optional
+        # switches (eco_mode, touch_lock). Mirror the pattern from
+        # test_command_subscriptions._e3800_device.
+        device = {
+            "device_key": "DEV1",
+            "device_name": "E3800",
+            "controls": {
+                "eco_quite_mode_as": {},
+                "device_touch_locking_as": {},
+                "battery_temp": {},
+                "charging_plate_temp": {},
+            },
+        }
+        b = HomeAssistantBridge({"discovery_prefix": "homeassistant"}, devices=[device])
+        b.client = MagicMock()
+        b._connected = True
+        b._publish_discovery()
+
+        # Extract slug from each command_topic: format is pecron/<dk>/<slug>/set
+        discovered_slugs = set()
+        for topic in b._command_topics:
+            parts = topic.split("/")
+            self.assertEqual(len(parts), 4, f"unexpected command_topic format: {topic}")
+            self.assertEqual(parts[0], "pecron")
+            self.assertEqual(parts[3], "set")
+            discovered_slugs.add(parts[2])
+
+        # Every discovered slug must be present in _ha_command's ctrl_map.
+        # We exercise this via the public surface: a known slug calls
+        # send_bool_control, an unknown one does not.
+        for slug in sorted(discovered_slugs):
+            with self.subTest(slug=slug):
+                m = make_monitor()
+                m._ha_command("dk0", slug, True)
+                m.send_bool_control.assert_called_once(),  # not silently dropped
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #54.

## The dispatch-side gap

PR #51 fixed the subscribe half of issue #49: `ha_bridge.py` now subscribes to every `command_topic` that `_publish_discovery` registers. Live testing on hardware afterward showed the same hardcoded list lurking one layer deeper -- in `monitor.py:_ha_command`.

When HA publishes to `pecron/<dk>/eco_mode/set` (or `/touch_lock/set`, or `/auto_light_flag_as/set`):
1. The bridge's `on_message` fires (good, subscribed via #49 fix)
2. `_handle_command` fires (good, generic)
3. `command_callback` fires (good, generic)
4. `monitor.py:_ha_command` fires -- and the `ctrl_map.get(control)` lookup returns `None`, so `send_bool_control` was never called and the command was dropped with no log

The user-visible symptom from #49 reproduces end-to-end: HA toggle UI looks live, device state never changes.

## Verified slug->TSL mapping (read from `ha_bridge.py`, not assumed)

Each row's source line is the `command_topic` registration in `_publish_discovery`. The TSL field is the writable BOOL on the device that the entity binds to (also visible in the same `_pub_config` block via `value_template`, and confirmed against `constants.E3800_FULL_TSL` -- all six are BOOL/RW).

| HA slug (in topic) | TSL field (writable) | `ha_bridge.py` line | Notes |
|---|---|---|---|
| `ac` | `ac_switch_hm` | 386 | core, was already mapped |
| `dc` | `dc_switch_hm` | 398 | core, was already mapped |
| `ups` | `ups_status_hm` | 410 | core, was already mapped |
| `eco_mode` | `eco_quite_mode_as` | 429 | E3800-only, gated by `_has(device, "eco_quite_mode_as")` |
| `touch_lock` | `device_touch_locking_as` | 443 | E3800-only, gated by `_has(device, "device_touch_locking_as")` |
| `auto_light_flag_as` | `auto_light_flag_as` | 628 | auto_dim entity; slug here is the TSL field name itself, not a friendly alias |

The `auto_light_flag_as` row is the noted inconsistency: the auto_dim switch (`unique_id: pecron_<dk>_auto_dim`) advertises its `command_topic` using the raw TSL field name as the slug rather than a friendly slug like `auto_dim`. The map keys it on `auto_light_flag_as` to match what HA actually publishes.

The `bypass` (line 489) and `beep` (line 731) entries in `_publish_discovery` are state-only switches with no `command_topic`, so they don't appear in `_command_topics` and don't need a dispatch entry. (Confirmed by `grep -n command_topic ha_bridge.py` returning exactly the six rows above plus the comments and the capture site at line 890.)

## Defense in depth

`_ha_command` now logs a WARN when it receives an unrecognized control:

```
HA command for unknown control 'made_up_thing' on dk0 -- no slug->TSL mapping (issue #54)
```

So if a future `ha_bridge` addition advertises a new switch without a parallel update here, the failure surfaces in logs instead of silently dropping. The comment block above the map points to issue #54 and notes that the architectural cleanup -- driving `ctrl_map` from discovery -- is deferred to a separate PR.

## Test plan

Stdlib `unittest` only (no pytest). New file `tests/unit/test_ha_command_dispatch.py`:

- [x] Parametrised: each slug in the verified table dispatches `send_bool_control(dk, <tsl_field>, True)` correctly
- [x] Same for `False`
- [x] Unknown slug (e.g. `made_up_thing`): `send_bool_control` NOT called AND a WARN log is emitted (verified via `assertLogs("pecron", level="WARNING")`)
- [x] Known slug stays quiet: no spurious WARN on the happy path
- [x] Regression guard: introspect `HomeAssistantBridge._publish_discovery._command_topics` and assert every advertised slug resolves through the new `ctrl_map`. Will fail if discovery adds a slug without updating monitor.
- [x] All 81 pre-existing tests still pass (`Ran 86 tests in 4.067s, OK`)

## Out of scope

The architectural "drive `ctrl_map` from discovery" refactor is deferred. This PR is the targeted quick-fix for #54.