### PR TITLE
fix: suppress LOCAL TCP shutdown-window zero-frame status log + HA publish (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to pecron-monitor are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [0.7.7] - 2026-05-03
+
+### Fixed
+- **Suppress LOCAL TCP shutdown-window zero-frames** (#60). When the inverter is gating off during a low-battery shutdown, local TCP returns a frame carrying fresh `battery_pct=0` and voltage but zeroed `total_input_power`, `total_output_power`, and `remain_time`. Those zeroes are technically real-time-truth (no current is flowing because the inverter is off) but they overwrote the cloud's last-known-good values in the misleading status log line and triggered an unnecessary HA publish + alert/rule pass during the 1-2 minute shutdown transition. `_process_data` now detects the shape (source in `{"LOCAL TCP", "BLE"}` + `battery_pct=0` + all power=0 + `remain<=0`) and skips the status log, HA publish, and rule evaluation for that single frame. Cloud MQTT continues to drive HA. Reproduction reported by @brucehoult in #57 / #60.
+
 ## [0.7.6] - 2026-05-03
 
 ### Changed

--- a/monitor.py
+++ b/monitor.py
@@ -693,6 +693,29 @@ class PecronMonitor:
                 self.ha_bridge.publish_state(device_key, kv)
             return  # Skip status log until voltage arrives
 
+        # Issue #60: suppress LOCAL TCP "shutdown-window zero-frame" placeholders.
+        # When the inverter is gating off during a low-battery shutdown, local TCP
+        # returns a frame with fresh battery_pct (0) and voltage but zeroed power
+        # and remain_time. Those zeroes are technically real-time-truth (no current
+        # is flowing because the inverter is off) but in HA they clobber the cloud's
+        # last-known-good values for the 1-2 minute shutdown window, making "if
+        # input < 5W for 10min" automations false-fire. Cloud MQTT continues to
+        # arrive concurrently and stays the source of truth for power fields
+        # during this transition.
+        is_local_shutdown_zero_frame = (
+            source in ("LOCAL TCP", "BLE")
+            and battery_pct == 0
+            and total_in == 0
+            and total_out == 0
+            and remain <= 0
+        )
+        if is_local_shutdown_zero_frame:
+            log.debug("Skipping %s shutdown-window zero-frame for %s "
+                      "(battery=0%%, voltage=%.1fV, all power=0) — letting cloud "
+                      "telemetry stay authoritative for HA during shutdown.",
+                      source, device_key, voltage)
+            return  # Don't update HA, don't re-fire alerts, don't log status
+
         # Track data source — prefer local transports over cloud
         # If we already have a local source, don't let cloud overwrite it
         # (cloud MQTT fires asynchronously and can arrive after local TCP)

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     python pecron_monitor.py --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"
 
 import argparse
 import json

--- a/tests/unit/test_local_shutdown_zero_frame.py
+++ b/tests/unit/test_local_shutdown_zero_frame.py
@@ -1,0 +1,118 @@
+"""Tests for issue #60: suppress LOCAL TCP shutdown-window zero-frames.
+
+When the inverter is gating off during a low-battery shutdown, local TCP
+returns a frame with fresh battery_pct (0) and voltage but zeroed power and
+remain_time. Those zeroes are technically real (the inverter has stopped
+drawing) but they overwrite the cloud's last-known-good values in HA for
+the 1-2 minute shutdown window, making "if input < 5W" automations false-fire.
+
+Bruce's reproduction (issue #60 / #57 comments): on E3600LFP at battery=0%,
+local TCP returned `In:0W Out:0W ⏱ 0h0m` while cloud simultaneously reported
+`In:1281W Out:1198W ⏱ 89h48m`.
+
+The fix: in `_process_data`, detect the shape (source in LOCAL TCP/BLE +
+battery_pct=0 + total_in=0 + total_out=0 + remain<=0) and skip the status
+log + HA publish for that single frame. Cloud MQTT continues to drive HA.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from monitor import PecronMonitor
+
+
+def _make_monitor():
+    """Construct a minimal PecronMonitor with the fields _process_data touches."""
+    m = PecronMonitor.__new__(PecronMonitor)
+    m.config = {"alerts": {}, "rules": []}
+    m.devices = [{"device_key": "DK_TEST", "device_name": "TestDevice"}]
+    m.latest_data = {}
+    m.data_sources = {}
+    m._last_logged_values = {}
+    m.last_alert = {}
+    m.last_rule_action = {}
+    m.rules = []
+    m.ha_bridge = MagicMock()
+    m.ha_bridge.publish_state = MagicMock()
+    return m
+
+
+# Bruce's frame shape from issue #60: battery=0%, voltage=47.7V, all power=0,
+# remain=0. Voltage and temperature are nested under host_packet_data_jdb because
+# that's the path SENSOR_FIELDS["voltage"] resolves; battery_percentage is at
+# top level.
+SHUTDOWN_ZERO_FRAME = {
+    "battery_percentage": 0,
+    "host_packet_data_jdb": {
+        "host_packet_voltage": 47.7,
+        "host_packet_temp": 31,
+        "host_packet_electric_percentage": 0,
+    },
+    "total_input_power": 0,
+    "total_output_power": 0,
+    "remain_time": 0,
+}
+
+
+class TestShutdownZeroFrameSuppression:
+    def test_local_tcp_shutdown_zero_frame_skips_ha_publish(self, caplog):
+        m = _make_monitor()
+        caplog.set_level(logging.DEBUG, logger="pecron")
+        m._process_data("DK_TEST", SHUTDOWN_ZERO_FRAME, source="LOCAL TCP")
+        m.ha_bridge.publish_state.assert_not_called()
+        assert any("shutdown-window zero-frame" in r.message for r in caplog.records)
+
+    def test_ble_shutdown_zero_frame_also_suppressed(self):
+        m = _make_monitor()
+        m._process_data("DK_TEST", SHUTDOWN_ZERO_FRAME, source="BLE")
+        m.ha_bridge.publish_state.assert_not_called()
+
+    def test_cloud_mqtt_zero_frame_NOT_suppressed(self):
+        # Same frame shape but source=CLOUD MQTT: cloud is the authoritative
+        # source for power, so 0 from cloud must reach HA. (E.g. device truly
+        # idle, cloud has caught up with the shutdown.)
+        m = _make_monitor()
+        m._process_data("DK_TEST", SHUTDOWN_ZERO_FRAME, source="CLOUD MQTT")
+        m.ha_bridge.publish_state.assert_called_once()
+
+    def test_local_tcp_with_real_power_NOT_suppressed(self):
+        # Local TCP frame at battery=0% but with non-zero power (impossible in
+        # practice but the suppression rule must require ALL power=0 to fire).
+        m = _make_monitor()
+        kv = dict(SHUTDOWN_ZERO_FRAME, total_input_power=100)
+        m._process_data("DK_TEST", kv, source="LOCAL TCP")
+        m.ha_bridge.publish_state.assert_called_once()
+
+    def test_local_tcp_with_battery_above_zero_NOT_suppressed(self):
+        # Same all-zero power but battery is 50%: that's a different shape
+        # (idle device, healthy battery) and should reach HA. Need to override
+        # the nested host_packet_electric_percentage path too because that's
+        # what SENSOR_FIELDS["battery_percent"] reads first.
+        m = _make_monitor()
+        kv = dict(
+            SHUTDOWN_ZERO_FRAME,
+            battery_percentage=50,
+            host_packet_data_jdb={
+                **SHUTDOWN_ZERO_FRAME["host_packet_data_jdb"],
+                "host_packet_electric_percentage": 50,
+            },
+        )
+        m._process_data("DK_TEST", kv, source="LOCAL TCP")
+        m.ha_bridge.publish_state.assert_called_once()
+
+    def test_local_tcp_with_remain_above_zero_NOT_suppressed(self):
+        # Power=0 but remain_time is positive: the inverter says it could run
+        # for some time, so this isn't the shutdown placeholder.
+        m = _make_monitor()
+        kv = dict(SHUTDOWN_ZERO_FRAME, remain_time=120)
+        m._process_data("DK_TEST", kv, source="LOCAL TCP")
+        m.ha_bridge.publish_state.assert_called_once()
+
+    def test_suppressed_frame_does_not_update_last_logged_values(self):
+        # The "values unchanged" dedupe in _process_data must not be poisoned
+        # by the suppressed shutdown frame.
+        m = _make_monitor()
+        m._process_data("DK_TEST", SHUTDOWN_ZERO_FRAME, source="LOCAL TCP")
+        assert "DK_TEST" not in m._last_logged_values


### PR DESCRIPTION
Fixes #60. Spun out of #57 during the v0.7.6 retro pass.

## What's broken

When the inverter is gating off during a low-battery shutdown, local TCP returns a frame with fresh `battery_pct=0` + voltage but zeroed `total_input_power`, `total_output_power`, and `remain_time`. @brucehoult captured the disagreement in #57:

```
19:43:37 INFO 🔋 0% | 47.7V | 31°C | ⚡ In:1281W Out:1198W | ⏱ 89h48m [via CLOUD MQTT]
...
19:43:40 INFO 🔋 0% | 47.7V | 31°C | ⚡ In:0W Out:0W | ⏱ 0h0m [via LOCAL TCP]
```

Cloud says `In:1281W`, local TCP says `In:0W`, three seconds apart. The LOCAL TCP zeroes are technically real (the inverter has stopped drawing) but they hit `_process_data` and produce:

1. A misleading status log line (the unit isn't actually pulling 0W, it's mid-shutdown).
2. An HA `publish_state` call that re-runs the per-field cache logic with placeholder zeroes.
3. Alert + rule evaluation against a frame that doesn't represent the unit's *recent* operational state.

(The HA cache itself is partially protected by the existing `packet_has_host` guard from #48, but the status log + the spurious rule pass + the alert fire-eligibility were not.)

## Fix

`_process_data` now detects the shape:

```
source in {"LOCAL TCP", "BLE"}
  AND battery_pct == 0
  AND total_in == 0
  AND total_out == 0
  AND remain <= 0
```

and skips the status log, the HA publish, and the alert + rule evaluation for that single frame. Cloud MQTT continues to drive HA through the transition.

## Test plan

`tests/unit/test_local_shutdown_zero_frame.py` adds 7 cases:

- LOCAL TCP shutdown-shape frame: skipped (no HA publish, debug log emitted)
- BLE shutdown-shape frame: also skipped
- Same shape but `source="CLOUD MQTT"`: NOT skipped (cloud is authoritative for power)
- Same shape but `total_input_power=100`: NOT skipped (real telemetry)
- Same shape but `battery_pct=50`: NOT skipped (different shape, idle device)
- Same shape but `remain_time=120`: NOT skipped (different shape)
- Suppressed frame doesn't poison `_last_logged_values`

All 228 tests pass (220 prior + 7 new + 1 from a parallel addition).

## Version

Bumps `__version__` to `0.7.7` and adds the corresponding CHANGELOG entry.

Per the new release-sync rule (saved in our memory after the v0.7.6 backfill): once this lands, README header gets bumped to v0.7.7 and a matching `gh release create v0.7.7` will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)