### PR TITLE
feat: restore AC/DC switch state after low-battery shutdown (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to pecron-monitor are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [0.7.9] - 2026-05-03
+
+### Added
+- **Restore AC/DC switch state after a low-battery shutdown** (#59). Opt-in via the new `restore_outputs_after_shutdown` config block (default `enabled: false`). When a device transitions offline at SoC at or below `shutdown_threshold_pct` (default 10%), the monitor snapshots the current AC/DC switch state to `~/.pecron-monitor-state.json`. When the device later comes back online after a gap of at least `minimum_offline_seconds` (default 120s — filters out cloud blips), a background worker re-issues the saved AC/DC commands every `retry_interval_seconds` (default 30s) until observed state matches the snapshot or `retry_timeout_seconds` (default 600s) elapses. Snapshots older than `snapshot_max_age_seconds` (default 24h) are discarded. Local-TCP path is preferred (matches the latency Bruce measured in #57). State verification is via observed `latest_data` rather than `send_control` return values, which makes the loop robust against the LCD-at-0%-silently-rejects-commands pattern Bruce documented. Reproducer scenario from #57 / @brucehoult.
+
 ## [0.7.8] - 2026-05-03
 
 ### Fixed

--- a/monitor.py
+++ b/monitor.py
@@ -7,10 +7,13 @@ MQTT connection, local transport management, and data processing.
 
 import json
 import logging
+import threading
 import time
 import urllib.parse
 import urllib.request
 from datetime import datetime
+
+import output_state
 
 try:
     import paho.mqtt.client as mqtt
@@ -106,6 +109,15 @@ class PecronMonitor:
         # from a user-requested offline run. Only the former should be retried.
         self._fell_back_to_offline = False
         self._last_cloud_retry_at = 0.0
+
+        # Restore-outputs-after-shutdown state (issue #59).
+        # We track per-device offline/online wall-clock to gate the restore on
+        # "at least N seconds offline" — that filters out network blips that
+        # don't represent a real device shutdown. The _restore_threads dict
+        # dedupes concurrent worker spawns (online flap re-triggering restore).
+        self._last_offline_at: dict[str, float] = {}
+        self._last_online_at: dict[str, float] = {}
+        self._restore_threads: dict[str, threading.Thread] = {}
 
     def _next_packet_id(self) -> int:
         self._packet_id = (self._packet_id + 1) % 65535
@@ -569,7 +581,10 @@ class PecronMonitor:
                 log.debug("bus_ message with empty kv: %s", list(payload["data"].keys()))
         elif topic_suffix == "onl_" and "data" in payload:
             online = payload["data"].get("value", 0) == 1
-            log.info("Device %s is now %s", device_key, "online" if online else "offline")
+            if online:
+                self._on_device_online(device_key)
+            else:
+                self._on_device_offline(device_key)
         elif topic_suffix == "ack_":
             log.debug("ACK received for device %s", device_key)
         elif topic_suffix == "sys_":
@@ -1248,6 +1263,191 @@ class PecronMonitor:
                         log.info("Got status via REST API for %s", dk)
                         self._merge_device_data(dk, kv)
                         self._process_data(dk, kv, source="REST API")
+
+    # --- Restore outputs after shutdown (issue #59) ---
+
+    @staticmethod
+    def _coerce_switch(v):
+        """ac_switch_hm / dc_switch_hm land in latest_data as bool, "ON"/"OFF" string,
+        0/1 int, or absent. Coerce to bool for snapshot/restore comparisons. None
+        passes through to signal "unobserved." """
+        if v is None:
+            return None
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, (int, float)):
+            return v != 0
+        if isinstance(v, str):
+            return v.upper() in ("ON", "TRUE", "1")
+        return bool(v)
+
+    def _extract_soc(self, kv: dict):
+        """Pull SoC % from kv with the same precedence as SENSOR_FIELDS["battery_percent"]:
+        host_packet_data_jdb.host_packet_electric_percentage first, then top-level
+        battery_percentage. Returns None if neither is present."""
+        host = kv.get("host_packet_data_jdb")
+        if isinstance(host, dict):
+            v = host.get("host_packet_electric_percentage")
+            if v is not None:
+                try:
+                    return int(float(v))
+                except (TypeError, ValueError):
+                    pass
+        v = kv.get("battery_percentage")
+        if v is not None:
+            try:
+                return int(float(v))
+            except (TypeError, ValueError):
+                pass
+        return None
+
+    def _restore_cfg(self) -> dict:
+        return self.config.get("restore_outputs_after_shutdown", {}) or {}
+
+    def _on_device_offline(self, device_key: str):
+        """Called when a `is now offline` event arrives. Snapshots the user's
+        current AC/DC switch state to disk if it looks like a low-battery
+        shutdown (SoC <= configured threshold)."""
+        now = time.time()
+        self._last_offline_at[device_key] = now
+        log.info("Device %s is now offline", device_key)
+
+        cfg = self._restore_cfg()
+        if not cfg.get("enabled", False):
+            return
+
+        threshold = int(cfg.get("shutdown_threshold_pct", 10))
+        kv = self.latest_data.get(device_key, {})
+        soc = self._extract_soc(kv)
+        if soc is None:
+            log.debug("No SoC observation for %s at offline transition; skipping snapshot",
+                      device_key)
+            return
+        if soc > threshold:
+            log.debug("Device %s went offline at SoC=%d%% (>%d%% threshold); not a "
+                      "low-battery shutdown — skipping snapshot.", device_key, soc, threshold)
+            return
+
+        ac_on = self._coerce_switch(kv.get("ac_switch_hm"))
+        dc_on = self._coerce_switch(kv.get("dc_switch_hm"))
+        # If either switch state is unobservable, snapshot what we have (default
+        # missing to False rather than refuse to snapshot — restore worker will
+        # only act on differences from observed live state anyway).
+        snap = output_state.OutputSnapshot.now(
+            ac_on=bool(ac_on) if ac_on is not None else False,
+            dc_on=bool(dc_on) if dc_on is not None else False,
+            soc_at_offline=soc,
+        )
+        try:
+            output_state.save(device_key, snap)
+        except OSError as e:
+            log.warning("Could not persist output snapshot for %s: %s", device_key, e)
+            return
+        log.info("Snapshotted output state for %s for shutdown-restore "
+                 "(SoC=%d%%, AC=%s, DC=%s)", device_key, soc, ac_on, dc_on)
+
+    def _on_device_online(self, device_key: str):
+        """Called when a `is now online` event arrives. If a snapshot exists
+        and the offline gap was long enough to be a real shutdown, spawns a
+        background worker to restore the AC/DC state."""
+        now = time.time()
+        self._last_online_at[device_key] = now
+        log.info("Device %s is now online", device_key)
+
+        cfg = self._restore_cfg()
+        if not cfg.get("enabled", False):
+            return
+
+        snap = output_state.get(device_key)
+        if snap is None:
+            return  # No snapshot, no restore.
+
+        max_age = int(cfg.get("snapshot_max_age_seconds", 86400))
+        age = snap.age_seconds()
+        if age > max_age:
+            log.warning("Discarding stale output snapshot for %s (age %.0fs > max %ds)",
+                        device_key, age, max_age)
+            output_state.clear(device_key)
+            return
+
+        min_offline = int(cfg.get("minimum_offline_seconds", 120))
+        last_offline = self._last_offline_at.get(device_key)
+        if last_offline is not None and (now - last_offline) < min_offline:
+            log.info("Online transition for %s within %.1fs of last offline (<%d "
+                     "minimum) — too brief to be a real shutdown, skipping restore.",
+                     device_key, now - last_offline, min_offline)
+            return
+
+        existing = self._restore_threads.get(device_key)
+        if existing is not None and existing.is_alive():
+            log.debug("Restore worker already running for %s; skipping duplicate spawn",
+                      device_key)
+            return
+
+        log.info("Starting restore worker for %s — target AC=%s, DC=%s "
+                 "(snapshot taken %.0fs ago at SoC=%d%%)",
+                 device_key, snap.ac_on, snap.dc_on, age, snap.soc_at_offline)
+        t = threading.Thread(
+            target=self._restore_outputs_worker,
+            args=(device_key, bool(snap.ac_on), bool(snap.dc_on)),
+            daemon=True,
+            name=f"restore-{device_key[:6]}",
+        )
+        self._restore_threads[device_key] = t
+        t.start()
+
+    def _restore_outputs_worker(self, device_key: str, target_ac: bool, target_dc: bool):
+        """Retry loop: every `retry_interval_seconds` (default 30s), check if
+        observed AC/DC state matches the target and re-issue commands if not.
+        Bail out when both match (success), when timeout elapses, or when the
+        monitor is shutting down. State verification is via observed
+        latest_data — robust against the LCD-at-0%-silently-rejects pattern
+        Bruce documented in #57."""
+        cfg = self._restore_cfg()
+        interval = max(1, int(cfg.get("retry_interval_seconds", 30)))
+        timeout = int(cfg.get("retry_timeout_seconds", 600))
+        started_at = time.time()
+
+        while time.time() - started_at < timeout:
+            if not self._running:
+                log.info("Monitor shutting down; restore worker for %s exiting", device_key)
+                return
+
+            kv = self.latest_data.get(device_key, {}) or {}
+            current_ac = self._coerce_switch(kv.get("ac_switch_hm"))
+            current_dc = self._coerce_switch(kv.get("dc_switch_hm"))
+
+            if current_ac == target_ac and current_dc == target_dc:
+                log.info("Restore complete for %s: AC=%s DC=%s", device_key,
+                         target_ac, target_dc)
+                output_state.clear(device_key)
+                return
+
+            if current_ac != target_ac:
+                log.info("Restore: setting AC=%s on %s (currently %s)",
+                         target_ac, device_key, current_ac)
+                try:
+                    self.set_ac(device_key, target_ac)
+                except Exception as e:
+                    log.warning("Restore: set_ac failed for %s: %s", device_key, e)
+
+            if current_dc != target_dc:
+                log.info("Restore: setting DC=%s on %s (currently %s)",
+                         target_dc, device_key, current_dc)
+                try:
+                    self.set_dc(device_key, target_dc)
+                except Exception as e:
+                    log.warning("Restore: set_dc failed for %s: %s", device_key, e)
+
+            time.sleep(interval)
+
+        kv = self.latest_data.get(device_key, {}) or {}
+        log.error("Restore for %s timed out after %ds; clearing snapshot. "
+                  "Target was AC=%s DC=%s; current is AC=%s DC=%s",
+                  device_key, timeout, target_ac, target_dc,
+                  self._coerce_switch(kv.get("ac_switch_hm")),
+                  self._coerce_switch(kv.get("dc_switch_hm")))
+        output_state.clear(device_key)
 
     def _token_needs_refresh(self) -> bool:
         if self.offline_mode:

--- a/output_state.py
+++ b/output_state.py
@@ -1,0 +1,136 @@
+"""Snapshot persistence for the restore-outputs-after-shutdown feature (#59).
+
+When a device transitions offline at low SoC (likely a low-battery shutdown),
+the monitor snapshots the user's current AC/DC switch state to disk. When the
+device later transitions back online, the snapshot is loaded and the worker
+re-applies the previous state. The on-disk format outlives monitor restarts
+so a restart during the offline window doesn't lose the snapshot.
+
+Storage: a single JSON file at `~/.pecron-monitor-state.json` (override via
+`PECRON_STATE_PATH` env for tests). Schema:
+
+    {
+      "snapshots": {
+        "<device_key>": {
+          "ac_on": bool,
+          "dc_on": bool,
+          "soc_at_offline": int,
+          "snapshotted_at": "<ISO8601 UTC>"
+        },
+        ...
+      }
+    }
+
+Atomic writes via temp-file-and-rename. Missing/corrupt files load as empty.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("pecron")
+
+
+def _state_path() -> Path:
+    """Resolve the on-disk path. Honor PECRON_STATE_PATH for tests."""
+    override = os.environ.get("PECRON_STATE_PATH")
+    if override:
+        return Path(override)
+    return Path.home() / ".pecron-monitor-state.json"
+
+
+@dataclass
+class OutputSnapshot:
+    ac_on: bool
+    dc_on: bool
+    soc_at_offline: int
+    snapshotted_at: str  # ISO8601 UTC
+
+    @classmethod
+    def now(cls, ac_on: bool, dc_on: bool, soc_at_offline: int) -> "OutputSnapshot":
+        return cls(
+            ac_on=bool(ac_on),
+            dc_on=bool(dc_on),
+            soc_at_offline=int(soc_at_offline),
+            snapshotted_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    def age_seconds(self, *, now: Optional[datetime] = None) -> float:
+        now = now or datetime.now(timezone.utc)
+        try:
+            taken_at = datetime.fromisoformat(self.snapshotted_at)
+        except ValueError:
+            return float("inf")
+        if taken_at.tzinfo is None:
+            taken_at = taken_at.replace(tzinfo=timezone.utc)
+        return (now - taken_at).total_seconds()
+
+
+def load_all() -> dict[str, OutputSnapshot]:
+    """Load all snapshots from disk. Empty dict on missing/corrupt file."""
+    path = _state_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning("Could not read %s (%s); treating as empty.", path, e)
+        return {}
+    snapshots = data.get("snapshots", {}) if isinstance(data, dict) else {}
+    out: dict[str, OutputSnapshot] = {}
+    for dk, raw in snapshots.items():
+        try:
+            out[dk] = OutputSnapshot(**raw)
+        except (TypeError, KeyError) as e:
+            log.warning("Skipping malformed snapshot for %s: %s", dk, e)
+    return out
+
+
+def _save_all(snapshots: dict[str, OutputSnapshot]) -> None:
+    """Atomic write: write to temp file in same dir, fsync, rename."""
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"snapshots": {dk: asdict(s) for dk, s in snapshots.items()}}
+    fd, tmp_str = tempfile.mkstemp(prefix=".pecron-state-", dir=str(path.parent))
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        tmp_path.replace(path)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def save(device_key: str, snap: OutputSnapshot) -> None:
+    """Insert or overwrite the snapshot for one device."""
+    snapshots = load_all()
+    snapshots[device_key] = snap
+    _save_all(snapshots)
+
+
+def clear(device_key: str) -> bool:
+    """Remove the snapshot for one device. Returns True if anything was removed."""
+    snapshots = load_all()
+    if device_key not in snapshots:
+        return False
+    del snapshots[device_key]
+    _save_all(snapshots)
+    return True
+
+
+def get(device_key: str) -> Optional[OutputSnapshot]:
+    return load_all().get(device_key)

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     python pecron_monitor.py --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.8"
+__version__ = "0.7.9"
 
 import argparse
 import json

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -345,6 +345,20 @@ def setup_wizard(auto=False):
                 "_comment": "Example rule. Edit or remove as needed.",
             },
         ],
+        "restore_outputs_after_shutdown": {
+            "enabled": False,
+            "shutdown_threshold_pct": 10,
+            "minimum_offline_seconds": 120,
+            "retry_interval_seconds": 30,
+            "retry_timeout_seconds": 600,
+            "snapshot_max_age_seconds": 86400,
+            "_comment": (
+                "When a device transitions offline at low SoC, snapshot AC/DC switch "
+                "state. When it later comes back online (e.g. mains restored after a "
+                "low-battery shutdown), restore the previous switches. See issue #59. "
+                "Set enabled: true to opt in; defaults are conservative."
+            ),
+        },
     }
 
     with open(CONFIG_PATH, "w") as f:

--- a/tests/unit/test_restore_outputs.py
+++ b/tests/unit/test_restore_outputs.py
@@ -1,0 +1,335 @@
+"""Tests for issue #59: restore AC/DC switch state after low-battery shutdown.
+
+Covers:
+- output_state.py persistence (snapshot save/load/clear, atomic write, age math).
+- _on_device_offline: snapshot creation gated on SoC <= shutdown_threshold_pct.
+- _on_device_online: minimum_offline_seconds gate, snapshot age guard, worker spawn dedupe.
+- _restore_outputs_worker: success path, retry-until-state-matches, timeout.
+
+Hardware testing of the actual low-battery shutdown is constrained: the E1500LFP
+on Kim Pine is the live UPS for the workstation (see
+feedback_e1500_is_kim_pine_ups.md), so all power-cut behavior is exercised
+via these synthetic tests rather than real device drains.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import output_state
+from monitor import PecronMonitor
+
+
+@pytest.fixture
+def tmp_state_path(tmp_path, monkeypatch):
+    p = tmp_path / "pecron-state.json"
+    monkeypatch.setenv("PECRON_STATE_PATH", str(p))
+    return p
+
+
+def _make_monitor(restore_cfg=None):
+    m = PecronMonitor.__new__(PecronMonitor)
+    m.config = {"alerts": {}, "rules": []}
+    if restore_cfg is not None:
+        m.config["restore_outputs_after_shutdown"] = restore_cfg
+    m.devices = [{"device_key": "DK", "device_name": "TestDevice"}]
+    m.latest_data = {}
+    m.data_sources = {}
+    m._last_logged_values = {}
+    m.last_alert = {}
+    m.last_rule_action = {}
+    m.rules = []
+    m._running = True
+    m._last_offline_at = {}
+    m._last_online_at = {}
+    m._restore_threads = {}
+    m.ha_bridge = MagicMock()
+    m.set_ac = MagicMock(return_value=True)
+    m.set_dc = MagicMock(return_value=True)
+    return m
+
+
+# -------------------- output_state persistence ----------------------
+
+
+class TestOutputStatePersistence:
+    def test_save_and_load_round_trip(self, tmp_state_path):
+        snap = output_state.OutputSnapshot.now(ac_on=True, dc_on=False, soc_at_offline=3)
+        output_state.save("DK1", snap)
+        loaded = output_state.get("DK1")
+        assert loaded is not None
+        assert loaded.ac_on is True
+        assert loaded.dc_on is False
+        assert loaded.soc_at_offline == 3
+
+    def test_save_overwrites_same_device(self, tmp_state_path):
+        output_state.save("DK", output_state.OutputSnapshot.now(True, True, 5))
+        output_state.save("DK", output_state.OutputSnapshot.now(False, False, 1))
+        assert output_state.get("DK").ac_on is False
+        assert output_state.get("DK").dc_on is False
+
+    def test_clear_removes_entry(self, tmp_state_path):
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 5))
+        assert output_state.clear("DK") is True
+        assert output_state.get("DK") is None
+
+    def test_clear_nonexistent_returns_false(self, tmp_state_path):
+        assert output_state.clear("NOPE") is False
+
+    def test_load_missing_file_returns_empty(self, tmp_state_path):
+        assert output_state.load_all() == {}
+
+    def test_load_corrupt_file_returns_empty(self, tmp_state_path, caplog):
+        tmp_state_path.write_text("not valid json")
+        caplog.set_level(logging.WARNING, logger="pecron")
+        assert output_state.load_all() == {}
+
+    def test_load_skips_malformed_entry(self, tmp_state_path):
+        tmp_state_path.write_text(json.dumps({
+            "snapshots": {
+                "GOOD": {"ac_on": True, "dc_on": False,
+                         "soc_at_offline": 5, "snapshotted_at": "2026-05-03T00:00:00+00:00"},
+                "BAD": {"ac_on": True},  # missing fields
+            }
+        }))
+        snaps = output_state.load_all()
+        assert "GOOD" in snaps
+        assert "BAD" not in snaps
+
+    def test_atomic_write_does_not_leave_temp_files(self, tmp_state_path, tmp_path):
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 5))
+        assert not list(tmp_path.glob(".pecron-state-*"))
+
+    def test_age_seconds_for_recent_snapshot(self, tmp_state_path):
+        snap = output_state.OutputSnapshot.now(True, False, 5)
+        assert snap.age_seconds() < 5
+
+    def test_age_seconds_for_malformed_timestamp(self, tmp_state_path):
+        snap = output_state.OutputSnapshot(
+            ac_on=True, dc_on=False, soc_at_offline=5,
+            snapshotted_at="not-a-date",
+        )
+        assert snap.age_seconds() == float("inf")
+
+
+# -------------------- offline event -> snapshot -----------------------
+
+
+class TestOnDeviceOffline:
+    def test_disabled_does_nothing(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": False})
+        m.latest_data["DK"] = {
+            "battery_percentage": 2,
+            "ac_switch_hm": True, "dc_switch_hm": False,
+        }
+        m._on_device_offline("DK")
+        assert output_state.get("DK") is None
+
+    def test_below_threshold_snapshots(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": True, "shutdown_threshold_pct": 10})
+        m.latest_data["DK"] = {
+            "battery_percentage": 2,
+            "ac_switch_hm": True, "dc_switch_hm": False,
+        }
+        m._on_device_offline("DK")
+        snap = output_state.get("DK")
+        assert snap is not None
+        assert snap.ac_on is True
+        assert snap.dc_on is False
+        assert snap.soc_at_offline == 2
+
+    def test_above_threshold_no_snapshot(self, tmp_state_path):
+        # Manual unplug at 50% — not a low-battery shutdown.
+        m = _make_monitor(restore_cfg={"enabled": True, "shutdown_threshold_pct": 10})
+        m.latest_data["DK"] = {"battery_percentage": 50, "ac_switch_hm": True}
+        m._on_device_offline("DK")
+        assert output_state.get("DK") is None
+
+    def test_no_soc_no_snapshot(self, tmp_state_path):
+        # Cold boot offline before any telemetry — can't tell if low-battery.
+        m = _make_monitor(restore_cfg={"enabled": True})
+        m._on_device_offline("DK")
+        assert output_state.get("DK") is None
+
+    def test_uses_host_packet_soc_when_top_level_absent(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": True, "shutdown_threshold_pct": 10})
+        m.latest_data["DK"] = {
+            "host_packet_data_jdb": {"host_packet_electric_percentage": 3},
+            "ac_switch_hm": True, "dc_switch_hm": True,
+        }
+        m._on_device_offline("DK")
+        snap = output_state.get("DK")
+        assert snap is not None
+        assert snap.soc_at_offline == 3
+        assert snap.dc_on is True
+
+    def test_string_switch_state_coerces_to_bool(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": True, "shutdown_threshold_pct": 10})
+        m.latest_data["DK"] = {
+            "battery_percentage": 2,
+            "ac_switch_hm": "ON", "dc_switch_hm": "OFF",
+        }
+        m._on_device_offline("DK")
+        snap = output_state.get("DK")
+        assert snap.ac_on is True
+        assert snap.dc_on is False
+
+    def test_records_offline_timestamp(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": False})  # disabled is fine — we test the timestamp
+        before = time.time()
+        m._on_device_offline("DK")
+        assert before <= m._last_offline_at["DK"] <= time.time()
+
+
+# -------------------- online event -> restore worker ------------------
+
+
+class TestOnDeviceOnline:
+    def test_disabled_does_nothing(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": False})
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 2))
+        m._on_device_online("DK")
+        assert "DK" not in m._restore_threads
+
+    def test_no_snapshot_no_worker(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": True})
+        m._on_device_online("DK")
+        assert "DK" not in m._restore_threads
+
+    def test_snapshot_too_brief_offline_skips(self, tmp_state_path):
+        # Online transition only 5s after offline transition: network blip,
+        # not a real shutdown. Don't fire restore.
+        m = _make_monitor(restore_cfg={"enabled": True, "minimum_offline_seconds": 120})
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 2))
+        m._last_offline_at["DK"] = time.time() - 5
+        m._on_device_online("DK")
+        assert "DK" not in m._restore_threads
+        # Snapshot should NOT be cleared in this path — a future, longer offline
+        # should still get a chance to fire restore.
+        assert output_state.get("DK") is not None
+
+    def test_stale_snapshot_discarded(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": True, "snapshot_max_age_seconds": 60})
+        snap = output_state.OutputSnapshot(
+            ac_on=True, dc_on=False, soc_at_offline=2,
+            snapshotted_at="2020-01-01T00:00:00+00:00",  # ancient
+        )
+        output_state.save("DK", snap)
+        m._on_device_online("DK")
+        assert "DK" not in m._restore_threads
+        assert output_state.get("DK") is None  # cleared
+
+    def test_long_offline_with_snapshot_spawns_worker(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": True, "minimum_offline_seconds": 120,
+                                       "retry_interval_seconds": 1,
+                                       "retry_timeout_seconds": 5})
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 2))
+        m._last_offline_at["DK"] = time.time() - 600  # 10 min ago
+
+        # Pre-seed latest_data so the worker's first iteration sees the target
+        # state already matched and exits quickly.
+        m.latest_data["DK"] = {"ac_switch_hm": True, "dc_switch_hm": False}
+
+        m._on_device_online("DK")
+        t = m._restore_threads.get("DK")
+        assert t is not None
+        t.join(timeout=3)
+        assert not t.is_alive()
+        # Snapshot should be cleared once worker confirms target state.
+        assert output_state.get("DK") is None
+
+    def test_worker_dedup_on_duplicate_online(self, tmp_state_path):
+        # If two online events arrive in rapid succession (cloud flap), only
+        # one worker should be running for the device.
+        m = _make_monitor(restore_cfg={"enabled": True, "minimum_offline_seconds": 1,
+                                       "retry_interval_seconds": 10,
+                                       "retry_timeout_seconds": 30})
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 2))
+        m._last_offline_at["DK"] = time.time() - 10
+        m.latest_data["DK"] = {"ac_switch_hm": False, "dc_switch_hm": False}
+
+        m._on_device_online("DK")
+        first = m._restore_threads["DK"]
+        m._on_device_online("DK")  # second event
+        second = m._restore_threads["DK"]
+        assert first is second  # same thread, no respawn
+        # Stop the worker to let the test exit.
+        m._running = False
+        first.join(timeout=15)
+
+
+# -------------------- restore worker: retry semantics -----------------
+
+
+class TestRestoreWorker:
+    def test_already_in_target_state_clears_snapshot(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"retry_interval_seconds": 1,
+                                       "retry_timeout_seconds": 5})
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 2))
+        m.latest_data["DK"] = {"ac_switch_hm": True, "dc_switch_hm": False}
+        m._restore_outputs_worker("DK", target_ac=True, target_dc=False)
+        assert output_state.get("DK") is None
+        m.set_ac.assert_not_called()
+        m.set_dc.assert_not_called()
+
+    def test_issues_set_ac_when_state_differs(self, tmp_state_path):
+        # Latest data shows AC=False; target is True. After the first iteration,
+        # we update latest_data to True so the second iteration exits.
+        m = _make_monitor(restore_cfg={"retry_interval_seconds": 0.05,
+                                       "retry_timeout_seconds": 2})
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 2))
+        m.latest_data["DK"] = {"ac_switch_hm": False, "dc_switch_hm": False}
+
+        # set_ac side-effect: flip the cached state so the next iteration
+        # observes the new value, mimicking telemetry catching up.
+        def _flip_ac(dk, on):
+            m.latest_data[dk]["ac_switch_hm"] = on
+            return True
+        m.set_ac = MagicMock(side_effect=_flip_ac)
+
+        m._restore_outputs_worker("DK", target_ac=True, target_dc=False)
+        assert m.set_ac.call_count >= 1
+        m.set_ac.assert_any_call("DK", True)
+        assert output_state.get("DK") is None
+
+    def test_issues_set_dc_when_state_differs(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"retry_interval_seconds": 0.05,
+                                       "retry_timeout_seconds": 2})
+        m.latest_data["DK"] = {"ac_switch_hm": False, "dc_switch_hm": False}
+
+        def _flip_dc(dk, on):
+            m.latest_data[dk]["dc_switch_hm"] = on
+            return True
+        m.set_dc = MagicMock(side_effect=_flip_dc)
+
+        m._restore_outputs_worker("DK", target_ac=False, target_dc=True)
+        m.set_dc.assert_any_call("DK", True)
+
+    def test_timeout_clears_snapshot_and_logs_error(self, tmp_state_path, caplog):
+        # set_ac always succeeds at the API layer but latest_data never
+        # reflects the change (mimics the LCD-at-0% silent rejection). After
+        # timeout, snapshot should be cleared and an ERROR logged.
+        m = _make_monitor(restore_cfg={"retry_interval_seconds": 0.05,
+                                       "retry_timeout_seconds": 0.2})
+        output_state.save("DK", output_state.OutputSnapshot.now(True, False, 2))
+        m.latest_data["DK"] = {"ac_switch_hm": False, "dc_switch_hm": False}
+        # set_ac is a no-op (default MagicMock) — latest_data stays False.
+
+        caplog.set_level(logging.ERROR, logger="pecron")
+        m._restore_outputs_worker("DK", target_ac=True, target_dc=False)
+        assert output_state.get("DK") is None
+        assert any("timed out" in r.message for r in caplog.records)
+
+    def test_monitor_shutdown_aborts_worker(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"retry_interval_seconds": 10,
+                                       "retry_timeout_seconds": 60})
+        m.latest_data["DK"] = {"ac_switch_hm": False, "dc_switch_hm": False}
+        m._running = False  # simulate shutdown before worker starts
+        m._restore_outputs_worker("DK", target_ac=True, target_dc=False)
+        m.set_ac.assert_not_called()


### PR DESCRIPTION
Fixes #59. Spec drawn directly from @brucehoult's test logs in #57 / #59 (the issue body lays out the empirical constraints).

## What it does

When a device transitions offline at low SoC (likely a low-battery shutdown), snapshot the user's AC/DC switch state to disk. When the device later comes back online after a real-shutdown-length gap, a background worker re-issues the saved commands, retrying every 30s until observed state matches or the timeout elapses.

## Opt-in by default

```yaml
restore_outputs_after_shutdown:
  enabled: false                    # default off — backward compatible
  shutdown_threshold_pct: 10        # snapshot only if SoC <= N at offline (Bruce's E3600 shut down at ~9%)
  minimum_offline_seconds: 120      # ignore offline-online gaps shorter than this (cloud blips)
  retry_interval_seconds: 30
  retry_timeout_seconds: 600        # 10 minutes
  snapshot_max_age_seconds: 86400   # discard snapshots older than 24h
```

`setup_wizard.py` writes this block (`enabled: false`) for new users so the field is surfaced and tunable. Existing users see the new code do nothing until they opt in.

## Architecture

```
onl_ msg arrives in _on_message
  │
  ├── going OFFLINE: _on_device_offline
  │     - if SoC <= shutdown_threshold_pct: snapshot ac_switch_hm, dc_switch_hm,
  │       and SoC to ~/.pecron-monitor-state.json
  │     - if SoC unobservable or > threshold: no snapshot (manual unplug, network blip)
  │
  └── going ONLINE: _on_device_online
        - load snapshot for this device_key
        - if no snapshot: nothing to do
        - if snapshot age > snapshot_max_age_seconds: discard, log warning
        - if (now - last_offline_at) < minimum_offline_seconds: too brief, skip
        - if worker already running for this device: dedupe
        - else spawn _restore_outputs_worker thread:
            - loop every retry_interval_seconds:
                read observed ac_switch_hm / dc_switch_hm from latest_data
                if both match snapshot.target: success, clear snapshot, exit
                if differs: call set_ac() / set_dc() with target value
            - on timeout: log ERROR, clear snapshot, exit
```

## Why use observed state for verification rather than send_control's return value

`send_control` falls back from local TCP to cloud MQTT when local fails, and cloud-MQTT publishes return True without any read-back. So a "True" return doesn't actually confirm the device applied the write. Bruce showed in #57 that at SoC=0% the device silently rejects local commands too — the LCD has to read 1% before they take.

Reading `latest_data["ac_switch_hm"]` after each loop iteration uses the existing telemetry pipeline as the verification signal: when the cloud's next state push reflects the new value, we know the device actually applied it. Robust against both transport layers' quirks.

## Test plan

`tests/unit/test_restore_outputs.py` — 28 cases covering:

- **Persistence (`output_state.py`)**: save/load round-trip, overwrite, clear, missing-file load returns empty, corrupt-file load returns empty (with warning), malformed-entry load skips just the bad one, atomic write doesn't leave temp files, age math (recent + malformed timestamp).
- **Offline path**: disabled does nothing, below-threshold snapshots, above-threshold doesn't, no-SoC doesn't, host-packet SoC fallback works, string switch state ("ON"/"OFF") coerces to bool, offline timestamp is recorded for the brief-offline gate.
- **Online path**: disabled does nothing, no-snapshot does nothing, too-brief-offline skips (and preserves snapshot), stale snapshot is discarded, long-offline-with-snapshot spawns a worker, duplicate online events dedupe to a single worker.
- **Worker loop**: already-in-target-state clears snapshot without calling set_ac/dc, issues set_ac when AC differs, issues set_dc when DC differs, timeout clears snapshot and logs ERROR, monitor shutdown aborts the worker before it issues commands.

All 267 tests pass (239 prior + 28 new).

## Hardware verification plan

Per `feedback_e1500_is_kim_pine_ups.md` (saved this session): the E1500LFP on Kim Pine is the live UPS for the workstation, so toggling its AC switch off ends my own session. **All power-cut testing is on Stills' E3800LFP only, never Kim Pine.**

Plan after CI green:

1. Deploy this branch to Stills with the default `enabled: false`. Watch one poll cycle to confirm no regressions in normal telemetry. The new code paths are dormant.
2. After Logan greenlight, flip Stills to `enabled: true` for soak. The E3800 stays at 100% trickle-charge under normal conditions, so no real shutdown will fire — but the offline/online hooks will exercise on every restart and we can verify no spurious snapshots/restores.
3. Real shutdown verification needs either a deliberate Stills E3800 drain (Logan's call — disruptive) or a Bruce repro on his E3600 in NZ (his existing #57 test logs show he's been doing this anyway). Logan-approval needed before pinging Bruce.
4. Kim Pine deploys keep `enabled: false` until step 3 has confirmed behavior on a real shutdown cycle on someone else's hardware.

## Version

Bumps `__version__` to `0.7.9`. README + GitHub Release will follow on merge per the release-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)