### PR TITLE
Release v0.7.11 voltage-based low battery triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to pecron-monitor are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
 
+## [0.7.11] - 2026-05-17
+
+### Added
+- **Voltage-based automation and shutdown-restore triggers** (#57, partial #56). Rules now support `voltage_below` and `voltage_above` conditions, and `restore_outputs_after_shutdown` can use optional `shutdown_threshold_voltage` in addition to the existing SoC threshold. This lets LFP users trigger low-battery behavior from pack voltage when SoC has drifted out of calibration.
+
 ## [0.7.10] - 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.7.10** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
+**v0.7.11** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 
@@ -137,6 +137,15 @@ rules:
     action:
       set_ac: false
     cooldown_minutes: 30
+
+restore_outputs_after_shutdown:
+  enabled: false
+  shutdown_threshold_pct: 10
+  shutdown_threshold_voltage: null  # Optional, e.g. 48.0 for voltage-based low-battery detection
+  minimum_offline_seconds: 120
+  retry_interval_seconds: 30
+  retry_timeout_seconds: 600
+  snapshot_max_age_seconds: 86400
 ```
 
 > **`poll_interval` floor.** Pecron's cloud rate-limits per-account at roughly 1280 polls/day (issue #29). The monitor refuses to use cloud polling below 63s and warns between 63 and 69s. Below 63s the cap trips daily around 23:00 UTC with `code 4026 'Insufficient resources'`. The default of 70s leaves comfortable margin. Local/offline mode (`--local`) is not subject to this cloud quota and may use faster polling for LAN/BLE monitoring. Raise cloud polling further if you're seeing 4026 in your logs.
@@ -155,11 +164,24 @@ rules:
 |-----------|---------|
 | `battery_below` | `10` — fires at or below 10% |
 | `battery_above` | `95` — fires at or above 95% |
+| `voltage_below` | `48.0` — fires at or below 48.0V |
+| `voltage_above` | `54.0` — fires at or above 54.0V |
 | `input_power_below` | `5` — no solar/charging input |
 | `input_power_above` | `100` — charging detected |
 | `schedule` | `"00:00"` — time-based (24h format) |
 
 Actions: `set_ac`, `set_dc`, `set_ups` (true/false)
+
+### Restore Outputs After Low-Battery Shutdown
+
+`restore_outputs_after_shutdown` is opt-in. When enabled, the monitor snapshots
+AC/DC switch state if the device goes offline at or below
+`shutdown_threshold_pct`. If SoC drifts on your LFP pack, set
+`shutdown_threshold_voltage` as an additional low-battery detector; either the
+percentage threshold or the voltage threshold can trigger the snapshot. When the
+unit later comes back online after `minimum_offline_seconds`, the monitor retries
+the saved AC/DC commands until telemetry confirms the switches match or
+`retry_timeout_seconds` elapses.
 
 ## Offline Mode
 

--- a/monitor.py
+++ b/monitor.py
@@ -1222,6 +1222,16 @@ class PecronMonitor:
                     if battery_pct < 0:
                         continue
                     triggered = battery_pct >= condition["battery_above"]
+                elif "voltage_below" in condition:
+                    voltage_now = self._extract_voltage(kv)
+                    if voltage_now is None:
+                        continue
+                    triggered = voltage_now <= float(condition["voltage_below"])
+                elif "voltage_above" in condition:
+                    voltage_now = self._extract_voltage(kv)
+                    if voltage_now is None:
+                        continue
+                    triggered = voltage_now >= float(condition["voltage_above"])
                 elif "input_power_below" in condition:
                     triggered = (
                         int(kv.get("total_input_power", 0)) <= condition["input_power_below"]
@@ -1492,13 +1502,28 @@ class PecronMonitor:
                 pass
         return None
 
+    def _extract_voltage(self, kv: dict):
+        """Pull battery voltage from kv. Returns None for missing/invalid values."""
+        for value in (kv.get("voltage"), _get_kv(kv, SENSOR_FIELDS["voltage"], 0)):
+            try:
+                voltage = float(value)
+            except (TypeError, ValueError):
+                continue
+            if voltage > 0:
+                return voltage
+        return None
+
     def _restore_cfg(self) -> dict:
         return self.config.get("restore_outputs_after_shutdown", {}) or {}
 
     def _on_device_offline(self, device_key: str):
-        """Called when a `is now offline` event arrives. Snapshots the user's
-        current AC/DC switch state to disk if it looks like a low-battery
-        shutdown (SoC <= configured threshold)."""
+        """Called when a `is now offline` event arrives.
+
+        Snapshot the user's current AC/DC switch state to disk if telemetry
+        indicates a low-battery shutdown. Percentage remains the default
+        threshold; voltage can be configured for LFP packs whose SoC estimate
+        drifts near empty.
+        """
         now = time.time()
         self._last_offline_at[device_key] = now
         log.info("Device %s is now offline", device_key)
@@ -1507,22 +1532,35 @@ class PecronMonitor:
         if not cfg.get("enabled", False):
             return
 
-        threshold = int(cfg.get("shutdown_threshold_pct", 10))
         kv = self.latest_data.get(device_key, {})
         soc = self._extract_soc(kv)
-        if soc is None:
-            log.debug(
-                "No SoC observation for %s at offline transition; skipping snapshot", device_key
-            )
-            return
-        if soc > threshold:
-            log.debug(
-                "Device %s went offline at SoC=%d%% (>%d%% threshold); not a "
-                "low-battery shutdown — skipping snapshot.",
-                device_key,
-                soc,
-                threshold,
-            )
+        voltage = self._extract_voltage(kv)
+        threshold_pct = int(cfg.get("shutdown_threshold_pct", 10))
+        threshold_voltage = cfg.get("shutdown_threshold_voltage")
+        if threshold_voltage is not None:
+            threshold_voltage = float(threshold_voltage)
+
+        pct_crossed = soc is not None and soc <= threshold_pct
+        voltage_crossed = (
+            threshold_voltage is not None and voltage is not None and voltage <= threshold_voltage
+        )
+        if not pct_crossed and not voltage_crossed:
+            if soc is None and (threshold_voltage is None or voltage is None):
+                log.debug(
+                    "No usable SoC/voltage observation for %s at offline transition; "
+                    "skipping snapshot",
+                    device_key,
+                )
+            else:
+                log.debug(
+                    "Device %s went offline at SoC=%s%% voltage=%sV; thresholds "
+                    "are SoC<=%d%% voltage<=%sV; skipping snapshot.",
+                    device_key,
+                    soc if soc is not None else "unknown",
+                    f"{voltage:.1f}" if voltage is not None else "unknown",
+                    threshold_pct,
+                    threshold_voltage if threshold_voltage is not None else "disabled",
+                )
             return
 
         ac_on = self._coerce_switch(kv.get("ac_switch_hm"))
@@ -1534,6 +1572,7 @@ class PecronMonitor:
             ac_on=bool(ac_on) if ac_on is not None else False,
             dc_on=bool(dc_on) if dc_on is not None else False,
             soc_at_offline=soc,
+            voltage_at_offline=voltage,
         )
         try:
             output_state.save(device_key, snap)
@@ -1541,9 +1580,11 @@ class PecronMonitor:
             log.warning("Could not persist output snapshot for %s: %s", device_key, e)
             return
         log.info(
-            "Snapshotted output state for %s for shutdown-restore (SoC=%d%%, AC=%s, DC=%s)",
+            "Snapshotted output state for %s for shutdown-restore "
+            "(SoC=%s%%, voltage=%sV, AC=%s, DC=%s)",
             device_key,
-            soc,
+            soc if soc is not None else "unknown",
+            f"{voltage:.1f}" if voltage is not None else "unknown",
             ac_on,
             dc_on,
         )

--- a/output_state.py
+++ b/output_state.py
@@ -1,10 +1,10 @@
 """Snapshot persistence for the restore-outputs-after-shutdown feature (#59).
 
-When a device transitions offline at low SoC (likely a low-battery shutdown),
-the monitor snapshots the user's current AC/DC switch state to disk. When the
-device later transitions back online, the snapshot is loaded and the worker
-re-applies the previous state. The on-disk format outlives monitor restarts
-so a restart during the offline window doesn't lose the snapshot.
+When a device transitions offline at low SoC or low voltage (likely a
+low-battery shutdown), the monitor snapshots the user's current AC/DC switch
+state to disk. When the device later transitions back online, the snapshot is
+loaded and the worker re-applies the previous state. The on-disk format outlives
+monitor restarts so a restart during the offline window doesn't lose the snapshot.
 
 Storage: a single JSON file at `~/.pecron-monitor-state.json` (override via
 `PECRON_STATE_PATH` env for tests). Schema:
@@ -14,7 +14,8 @@ Storage: a single JSON file at `~/.pecron-monitor-state.json` (override via
         "<device_key>": {
           "ac_on": bool,
           "dc_on": bool,
-          "soc_at_offline": int,
+          "soc_at_offline": int | null,
+          "voltage_at_offline": float | null,
           "snapshotted_at": "<ISO8601 UTC>"
         },
         ...
@@ -50,15 +51,25 @@ def _state_path() -> Path:
 class OutputSnapshot:
     ac_on: bool
     dc_on: bool
-    soc_at_offline: int
+    soc_at_offline: Optional[int]
     snapshotted_at: str  # ISO8601 UTC
+    voltage_at_offline: Optional[float] = None
 
     @classmethod
-    def now(cls, ac_on: bool, dc_on: bool, soc_at_offline: int) -> "OutputSnapshot":
+    def now(
+        cls,
+        ac_on: bool,
+        dc_on: bool,
+        soc_at_offline: Optional[int],
+        voltage_at_offline: Optional[float] = None,
+    ) -> "OutputSnapshot":
         return cls(
             ac_on=bool(ac_on),
             dc_on=bool(dc_on),
-            soc_at_offline=int(soc_at_offline),
+            soc_at_offline=int(soc_at_offline) if soc_at_offline is not None else None,
+            voltage_at_offline=(
+                float(voltage_at_offline) if voltage_at_offline is not None else None
+            ),
             snapshotted_at=datetime.now(timezone.utc).isoformat(),
         )
 

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     pecron-monitor --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.10"
+__version__ = "0.7.11"
 
 import argparse
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pecron-monitor"
-version = "0.7.10"
+version = "0.7.11"
 description = "Monitor and control Pecron portable power stations from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -372,14 +372,17 @@ def setup_wizard(auto=False):
         "restore_outputs_after_shutdown": {
             "enabled": False,
             "shutdown_threshold_pct": 10,
+            "shutdown_threshold_voltage": None,
             "minimum_offline_seconds": 120,
             "retry_interval_seconds": 30,
             "retry_timeout_seconds": 600,
             "snapshot_max_age_seconds": 86400,
             "_comment": (
-                "When a device transitions offline at low SoC, snapshot AC/DC switch "
-                "state. When it later comes back online (e.g. mains restored after a "
-                "low-battery shutdown), restore the previous switches. See issue #59. "
+                "When a device transitions offline at low SoC or low voltage, snapshot "
+                "AC/DC switch state. When it later comes back online (e.g. mains "
+                "restored after a low-battery shutdown), restore the previous switches. "
+                "Set shutdown_threshold_voltage to a pack voltage such as 48.0 if SoC "
+                "drift makes percentage unreliable near empty. See issue #59/#57. "
                 "Set enabled: true to opt in; defaults are conservative."
             ),
         },

--- a/tests/unit/test_restore_outputs.py
+++ b/tests/unit/test_restore_outputs.py
@@ -65,6 +65,19 @@ class TestOutputStatePersistence:
         assert loaded.dc_on is False
         assert loaded.soc_at_offline == 3
 
+    def test_save_and_load_round_trip_with_voltage(self, tmp_state_path):
+        snap = output_state.OutputSnapshot.now(
+            ac_on=True,
+            dc_on=False,
+            soc_at_offline=None,
+            voltage_at_offline=47.8,
+        )
+        output_state.save("DK1", snap)
+        loaded = output_state.get("DK1")
+        assert loaded is not None
+        assert loaded.soc_at_offline is None
+        assert loaded.voltage_at_offline == 47.8
+
     def test_save_overwrites_same_device(self, tmp_state_path):
         output_state.save("DK", output_state.OutputSnapshot.now(True, True, 5))
         output_state.save("DK", output_state.OutputSnapshot.now(False, False, 1))
@@ -157,6 +170,55 @@ class TestOnDeviceOffline:
         # Manual unplug at 50% — not a low-battery shutdown.
         m = _make_monitor(restore_cfg={"enabled": True, "shutdown_threshold_pct": 10})
         m.latest_data["DK"] = {"battery_percentage": 50, "ac_switch_hm": True}
+        m._on_device_offline("DK")
+        assert output_state.get("DK") is None
+
+    def test_voltage_threshold_snapshots_when_soc_is_not_low(self, tmp_state_path):
+        m = _make_monitor(
+            restore_cfg={
+                "enabled": True,
+                "shutdown_threshold_pct": 10,
+                "shutdown_threshold_voltage": 48.0,
+            }
+        )
+        m.latest_data["DK"] = {
+            "battery_percentage": 50,
+            "voltage": 47.8,
+            "ac_switch_hm": True,
+            "dc_switch_hm": False,
+        }
+        m._on_device_offline("DK")
+        snap = output_state.get("DK")
+        assert snap is not None
+        assert snap.soc_at_offline == 50
+        assert snap.voltage_at_offline == 47.8
+
+    def test_voltage_threshold_snapshots_without_soc(self, tmp_state_path):
+        m = _make_monitor(restore_cfg={"enabled": True, "shutdown_threshold_voltage": 48.0})
+        m.latest_data["DK"] = {
+            "voltage": 47.8,
+            "ac_switch_hm": True,
+            "dc_switch_hm": False,
+        }
+        m._on_device_offline("DK")
+        snap = output_state.get("DK")
+        assert snap is not None
+        assert snap.soc_at_offline is None
+        assert snap.voltage_at_offline == 47.8
+
+    def test_voltage_above_threshold_no_snapshot(self, tmp_state_path):
+        m = _make_monitor(
+            restore_cfg={
+                "enabled": True,
+                "shutdown_threshold_pct": 10,
+                "shutdown_threshold_voltage": 48.0,
+            }
+        )
+        m.latest_data["DK"] = {
+            "battery_percentage": 50,
+            "voltage": 48.2,
+            "ac_switch_hm": True,
+        }
         m._on_device_offline("DK")
         assert output_state.get("DK") is None
 

--- a/tests/unit/test_rules_voltage.py
+++ b/tests/unit/test_rules_voltage.py
@@ -1,0 +1,64 @@
+"""Tests for voltage-based automation rule conditions (#56/#57)."""
+
+from unittest.mock import MagicMock
+
+from monitor import PecronMonitor
+
+
+def _monitor_with_rule(condition):
+    config = {
+        "email": "test@example.com",
+        "password": "test",
+        "region": "na",
+        "devices": [],
+        "rules": [
+            {
+                "name": "voltage rule",
+                "condition": condition,
+                "action": {"set_ac": False},
+                "cooldown_minutes": 0,
+            }
+        ],
+    }
+    monitor = PecronMonitor(config)
+    monitor.devices = [
+        {
+            "device_key": "DK",
+            "device_name": "TestDevice",
+            "controls": {"ac_switch_hm": {}},
+        }
+    ]
+    monitor.set_ac = MagicMock(return_value=True)
+    return monitor
+
+
+def test_voltage_below_triggers_action():
+    monitor = _monitor_with_rule({"voltage_below": 48.0})
+
+    monitor._evaluate_rules("DK", {"battery_percentage": 50, "voltage": 47.9}, 50)
+
+    monitor.set_ac.assert_called_once_with("DK", False)
+
+
+def test_voltage_below_does_not_trigger_above_threshold():
+    monitor = _monitor_with_rule({"voltage_below": 48.0})
+
+    monitor._evaluate_rules("DK", {"battery_percentage": 50, "voltage": 48.1}, 50)
+
+    monitor.set_ac.assert_not_called()
+
+
+def test_voltage_above_triggers_action():
+    monitor = _monitor_with_rule({"voltage_above": 54.0})
+
+    monitor._evaluate_rules("DK", {"battery_percentage": 90, "voltage": 54.1}, 90)
+
+    monitor.set_ac.assert_called_once_with("DK", False)
+
+
+def test_missing_voltage_does_not_trigger():
+    monitor = _monitor_with_rule({"voltage_below": 48.0})
+
+    monitor._evaluate_rules("DK", {"battery_percentage": 50}, 50)
+
+    monitor.set_ac.assert_not_called()


### PR DESCRIPTION
## Summary
- release v0.7.11 with voltage-based low-battery triggers
- add `voltage_below` / `voltage_above` automation rule conditions
- add optional `restore_outputs_after_shutdown.shutdown_threshold_voltage` alongside the existing SoC threshold
- persist optional voltage at offline snapshot time

## Verification
- python3 -m pytest tests/unit/test_restore_outputs.py tests/unit/test_rules_voltage.py -q
- python3 -m ruff check .
- python3 -m ruff format --check .
- python3 -m py_compile pecron_monitor.py local_transport.py
- python3 -m pytest -q --cov=. --cov-report=term-missing
- live Stills status check on E3800/E1500 using the branch

Fixes #57
Refs #56