### PR TITLE
Release v0.7.12 rules engine state and commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to pecron-monitor are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
 
+## [0.7.12] - 2026-05-17
+
+### Added
+- **Rules engine state and init/external-command actions** (#56). Rules can now gate on persisted `state` / `states`, fire once at service startup via `init`, transition state with `set_state`, and run external commands with rule/device telemetry JSON on stdin via `run_command`. State is persisted to `~/.pecron-monitor-rules.json` by default, configurable with `rule_state.path` or `PECRON_RULE_STATE_PATH`.
+
 ## [0.7.11] - 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.7.11** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
+**v0.7.12** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 
@@ -130,10 +130,15 @@ alerts:
     bot_token: "your-bot-token"
     chat_id: "your-chat-id"
 
+rule_state:
+  initial_state: normal
+  # path: ~/.pecron-monitor-rules.json
+
 rules:
   - name: "Low battery — turn off AC"
     condition:
       battery_below: 10
+      state: normal        # Optional: only fires while persisted rule state is "normal"
     action:
       set_ac: false
     cooldown_minutes: 30
@@ -169,8 +174,22 @@ restore_outputs_after_shutdown:
 | `input_power_below` | `5` — no solar/charging input |
 | `input_power_above` | `100` — charging detected |
 | `schedule` | `"00:00"` — time-based (24h format) |
+| `init` | `true` — fires once when the service starts |
+| `state` | `"normal"` — only evaluate this rule in one state |
+| `states` | `["normal", "peak"]` — only evaluate this rule in any listed state |
 
-Actions: `set_ac`, `set_dc`, `set_ups` (true/false)
+Actions: `set_ac`, `set_dc`, `set_ups` (true/false), `set_state`, `run_command`
+
+Rule state is a single persisted string. Set the initial value with
+`rule_state.initial_state`; by default state is saved at
+`~/.pecron-monitor-rules.json` and survives service restarts. Use `set_state` to
+transition between states.
+
+`run_command` executes an external command without a shell. Provide either an
+argv list or a string that can be split like a shell command. The monitor sends
+JSON on stdin containing the rule name, current state, device key, target device
+key, battery percent, voltage, and raw telemetry. Use `timeout_seconds` on the
+action to override the 30s default.
 
 ### Restore Outputs After Low-Battery Shutdown
 

--- a/monitor.py
+++ b/monitor.py
@@ -5,13 +5,18 @@ Contains the PecronMonitor class which orchestrates cloud authentication,
 MQTT connection, local transport management, and data processing.
 """
 
+import os
 import json
+import shlex
+import subprocess
+import tempfile
 import logging
 import threading
 import time
 import urllib.parse
 import urllib.request
 from datetime import datetime
+from pathlib import Path
 
 import output_state
 
@@ -117,6 +122,9 @@ class PecronMonitor:
 
         # Automation rules
         self.rules = config.get("rules", [])
+        self.rule_state_config = config.get("rule_state", {}) or {}
+        self.rule_state = self._load_rule_state()
+        self._init_rules_ran = False
 
         self._mqtt_connect_failures = 0
         self._last_mqtt_rebuild_at = 0.0
@@ -1189,12 +1197,126 @@ class PecronMonitor:
 
     # --- Automation rules ---
 
-    def _evaluate_rules(self, device_key: str, kv: dict, battery_pct: int):
+    def _rule_state_path(self) -> Path:
+        """Resolve persisted rule-state path."""
+        override = os.environ.get("PECRON_RULE_STATE_PATH")
+        if override:
+            return Path(override)
+        configured = self.rule_state_config.get("path") or self.config.get("rule_state_path")
+        if configured:
+            return Path(configured).expanduser()
+        return Path.home() / ".pecron-monitor-rules.json"
+
+    def _initial_rule_state(self) -> str:
+        """Return configured initial rule state."""
+        return str(self.rule_state_config.get("initial_state", "default"))
+
+    def _load_rule_state(self) -> str:
+        """Load persisted rule state, falling back to the configured initial state."""
+        path = self._rule_state_path()
+        fallback = self._initial_rule_state()
+        if not path.exists():
+            return fallback
+        try:
+            with path.open("r") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            log.warning("Could not load rule state from %s: %s", path, e)
+            return fallback
+        state = data.get("state") if isinstance(data, dict) else None
+        return str(state) if state else fallback
+
+    def _save_rule_state(self) -> None:
+        """Persist current rule state atomically."""
+        path = self._rule_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=".pecron-rules-", dir=str(path.parent))
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(
+                    {"state": self.rule_state, "updated_at": datetime.utcnow().isoformat()},
+                    f,
+                )
+                f.write("\n")
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            raise
+
+    def _set_rule_state(self, state: str) -> None:
+        """Change and persist the single rule engine state."""
+        new_state = str(state)
+        if new_state == self.rule_state:
+            return
+        old_state = self.rule_state
+        self.rule_state = new_state
+        self._save_rule_state()
+        log.info("Rule state changed: %s -> %s", old_state, new_state)
+
+    def _rule_state_matches(self, condition: dict) -> bool:
+        """Return whether current state satisfies a rule condition's state gate."""
+        if "state" in condition:
+            return self.rule_state == str(condition["state"])
+        states = condition.get("states")
+        if states is None:
+            return True
+        if isinstance(states, str):
+            return self.rule_state == states
+        return self.rule_state in {str(state) for state in states}
+
+    def _run_rule_command(
+        self,
+        command,
+        *,
+        rule: dict,
+        action: dict,
+        device_key: str,
+        target_device_key: str,
+        kv: dict,
+        battery_pct: int,
+    ) -> None:
+        """Run a configured external command with rule context on stdin as JSON."""
+        if isinstance(command, str):
+            argv = shlex.split(command)
+        else:
+            argv = [str(part) for part in command]
+        if not argv:
+            raise ValueError("run_command cannot be empty")
+
+        payload = {
+            "rule": rule.get("name"),
+            "state": self.rule_state,
+            "device_key": device_key,
+            "target_device_key": target_device_key,
+            "battery_percent": battery_pct,
+            "voltage": self._extract_voltage(kv),
+            "data": kv,
+        }
+        timeout = float(action.get("timeout_seconds", 30))
+        result = subprocess.run(
+            argv,
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        if result.stdout.strip():
+            log.info("Rule '%s' command stdout: %s", rule.get("name"), result.stdout.strip())
+        if result.stderr.strip():
+            log.warning("Rule '%s' command stderr: %s", rule.get("name"), result.stderr.strip())
+        if result.returncode != 0:
+            raise RuntimeError(f"command exited with status {result.returncode}: {argv[0]}")
+
+    def _evaluate_rules(self, device_key: str, kv: dict, battery_pct: int, *, init: bool = False):
         """Evaluate automation rules against current state."""
-        # Sanity check: prevent rule triggers on invalid data
-        # If battery is -1 or 0 AND voltage is 0, the data is clearly invalid
-        voltage = float(_get_kv(kv, SENSOR_FIELDS["voltage"], 0))
-        if battery_pct <= 0 and voltage == 0:
+        # Sanity check: prevent rule triggers on invalid non-init data.
+        voltage = self._extract_voltage(kv) or 0
+        if not init and battery_pct <= 0 and voltage == 0:
             log.debug(
                 "Skipping rule evaluation for %s: invalid data (battery=%d%%, voltage=%.1fV)",
                 device_key,
@@ -1211,9 +1333,16 @@ class PecronMonitor:
                 condition = rule.get("condition", {})
                 action = rule.get("action", {})
 
-                # Check condition
+                if not self._rule_state_matches(condition):
+                    continue
+
+                # Check condition. `state`/`states` are preconditions, not
+                # triggers by themselves; they must be paired with another
+                # condition such as init, voltage_below, or schedule.
                 triggered = False
-                if "battery_below" in condition:
+                if condition.get("init"):
+                    triggered = init
+                elif "battery_below" in condition:
                     # Ignore invalid battery readings (-1 means no data)
                     if battery_pct < 0:
                         continue
@@ -1325,8 +1454,34 @@ class PecronMonitor:
                             target_dk,
                         )
 
+                if "set_state" in action:
+                    self._set_rule_state(action["set_state"])
+                    log.info("Rule '%s': set state=%s", rule.get("name"), action["set_state"])
+
+                if "run_command" in action:
+                    self._run_rule_command(
+                        action["run_command"],
+                        rule=rule,
+                        action=action,
+                        device_key=device_key,
+                        target_device_key=target_dk,
+                        kv=kv,
+                        battery_pct=battery_pct,
+                    )
+
             except Exception as e:
                 log.error("Rule evaluation error: %s", e)
+
+    def _run_init_rules(self) -> None:
+        """Evaluate rules with condition.init once after devices are available."""
+        if self._init_rules_ran:
+            return
+        self._init_rules_ran = True
+        for device in self.devices:
+            device_key = device["device_key"]
+            kv = self.latest_data.get(device_key, {})
+            battery_pct = int(_get_kv(kv, SENSOR_FIELDS["battery_percent"], -1))
+            self._evaluate_rules(device_key, kv, battery_pct, init=True)
 
     # --- Status request ---
 
@@ -1842,6 +1997,8 @@ class PecronMonitor:
                 self.ha_bridge = HomeAssistantBridge(ha_config, self.devices)
                 self.ha_bridge.command_callback = self._ha_command
                 self.ha_bridge.connect()
+
+        self._run_init_rules()
 
         log.info("Monitoring started (polling every %ds)", poll_interval)
 

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     pecron-monitor --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.11"
+__version__ = "0.7.12"
 
 import argparse
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pecron-monitor"
-version = "0.7.11"
+version = "0.7.12"
 description = "Monitor and control Pecron portable power stations from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -360,6 +360,10 @@ def setup_wizard(auto=False):
             "mqtt_password": ha_pw,
             "discovery_prefix": "homeassistant",
         },
+        "rule_state": {
+            "initial_state": "default",
+            "_comment": "Persisted rules-engine state. Add path to override ~/.pecron-monitor-rules.json.",
+        },
         "rules": [
             {
                 "name": "Low battery — turn off AC",

--- a/tests/unit/test_rules_engine_state.py
+++ b/tests/unit/test_rules_engine_state.py
@@ -1,0 +1,143 @@
+"""Tests for rules engine state, init, and external commands (#56)."""
+
+import json
+import sys
+from unittest.mock import MagicMock
+
+from monitor import PecronMonitor
+
+
+def _make_monitor(tmp_path, rules, *, initial_state="normal"):
+    config = {
+        "email": "test@example.com",
+        "password": "test",
+        "region": "na",
+        "devices": [],
+        "rule_state": {
+            "initial_state": initial_state,
+            "path": str(tmp_path / "rules-state.json"),
+        },
+        "rules": rules,
+    }
+    monitor = PecronMonitor(config)
+    monitor.devices = [
+        {
+            "device_key": "DK",
+            "device_name": "TestDevice",
+            "controls": {"ac_switch_hm": {}, "dc_switch_hm": {}, "ups_status_hm": {}},
+        }
+    ]
+    monitor.set_ac = MagicMock(return_value=True)
+    monitor.set_dc = MagicMock(return_value=True)
+    monitor.set_ups = MagicMock(return_value=True)
+    return monitor
+
+
+def test_rule_state_action_persists_and_new_monitor_loads_it(tmp_path):
+    rules = [
+        {
+            "name": "enter low state",
+            "condition": {"state": "normal", "battery_below": 50},
+            "action": {"set_state": "low"},
+            "cooldown_minutes": 0,
+        }
+    ]
+    monitor = _make_monitor(tmp_path, rules)
+
+    monitor._evaluate_rules("DK", {"battery_percentage": 40, "voltage": 52.0}, 40)
+
+    assert monitor.rule_state == "low"
+    state_file = tmp_path / "rules-state.json"
+    assert json.loads(state_file.read_text())["state"] == "low"
+    reloaded = _make_monitor(tmp_path, [], initial_state="normal")
+    assert reloaded.rule_state == "low"
+
+
+def test_state_gate_prevents_rule_in_wrong_state(tmp_path):
+    monitor = _make_monitor(
+        tmp_path,
+        [
+            {
+                "name": "only peak",
+                "condition": {"state": "peak", "battery_below": 50},
+                "action": {"set_ac": False},
+                "cooldown_minutes": 0,
+            }
+        ],
+    )
+
+    monitor._evaluate_rules("DK", {"battery_percentage": 40, "voltage": 52.0}, 40)
+
+    monitor.set_ac.assert_not_called()
+
+
+def test_states_gate_accepts_any_listed_state(tmp_path):
+    monitor = _make_monitor(
+        tmp_path,
+        [
+            {
+                "name": "normal or peak",
+                "condition": {"states": ["normal", "peak"], "battery_below": 50},
+                "action": {"set_dc": False},
+                "cooldown_minutes": 0,
+            }
+        ],
+    )
+
+    monitor._evaluate_rules("DK", {"battery_percentage": 40, "voltage": 52.0}, 40)
+
+    monitor.set_dc.assert_called_once_with("DK", False)
+
+
+def test_init_rule_fires_once(tmp_path):
+    monitor = _make_monitor(
+        tmp_path,
+        [
+            {
+                "name": "startup ac off",
+                "condition": {"init": True},
+                "action": {"set_ac": False},
+                "cooldown_minutes": 0,
+            }
+        ],
+    )
+
+    monitor._run_init_rules()
+    monitor._run_init_rules()
+
+    monitor.set_ac.assert_called_once_with("DK", False)
+
+
+def test_run_command_receives_rule_context_json(tmp_path):
+    script = tmp_path / "capture_rule_payload.py"
+    output = tmp_path / "payload.json"
+    script.write_text(
+        "import json, pathlib, sys\n"
+        "payload = json.load(sys.stdin)\n"
+        "pathlib.Path(sys.argv[1]).write_text(json.dumps(payload, sort_keys=True))\n"
+    )
+    monitor = _make_monitor(
+        tmp_path,
+        [
+            {
+                "name": "external command",
+                "condition": {"battery_below": 50},
+                "action": {
+                    "run_command": [sys.executable, str(script), str(output)],
+                    "timeout_seconds": 5,
+                },
+                "cooldown_minutes": 0,
+            }
+        ],
+    )
+
+    monitor._evaluate_rules("DK", {"battery_percentage": 40, "voltage": 51.2}, 40)
+
+    payload = json.loads(output.read_text())
+    assert payload["rule"] == "external command"
+    assert payload["state"] == "normal"
+    assert payload["device_key"] == "DK"
+    assert payload["target_device_key"] == "DK"
+    assert payload["battery_percent"] == 40
+    assert payload["voltage"] == 51.2
+    assert payload["data"]["battery_percentage"] == 40


### PR DESCRIPTION
## Summary
- release v0.7.12 with persisted rules-engine state
- add `state` / `states` rule gates and `set_state` transitions
- add one-shot startup rules via `condition.init: true`
- add safe external command action via `run_command` with rule/device telemetry JSON on stdin

## Notes
- `run_command` executes argv directly without a shell. This intentionally does not implement arbitrary Python execution from config.
- Rule state persists to `~/.pecron-monitor-rules.json` by default and can be overridden with `rule_state.path` or `PECRON_RULE_STATE_PATH`.

## Verification
- python3 -m pytest tests/unit/test_rules_engine_state.py tests/unit/test_rules_voltage.py -q
- python3 -m ruff check .
- python3 -m ruff format --check .
- python3 -m py_compile pecron_monitor.py local_transport.py
- python3 -m pytest -q --cov=. --cov-report=term-missing

Refs #56