### PR TITLE
Release v0.7.13 refresh Home Assistant discovery payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to pecron-monitor are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
 
+## [0.7.13] - 2026-05-17
+
+### Fixed
+- **Home Assistant discovery payload changes apply on service restart**. The bridge now clears each current retained discovery topic immediately before republishing it, forcing HA to reload changed discovery fields without a manual MQTT integration reload. Set `homeassistant.clear_discovery_on_startup: false` to keep the previous publish-only behavior.
+
 ## [0.7.12] - 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.7.12** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
+**v0.7.13** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 
@@ -243,9 +243,17 @@ homeassistant:
   mqtt_port: 1883
   mqtt_user: "user"
   mqtt_password: "pass"
+  discovery_prefix: "homeassistant"
+  clear_discovery_on_startup: true
 ```
 
 Run with `--homeassistant` or just start normally (auto-detects if enabled). Your Pecron appears in HA with battery sensors, power sensors, remaining time, and AC/DC/UPS switches.
+
+By default, the bridge clears each current retained discovery topic before
+republishing it on startup. This makes Home Assistant pick up discovery payload
+field changes after a service restart instead of requiring a manual MQTT
+integration reload. Set `clear_discovery_on_startup: false` if you need the old
+publish-only behavior.
 
 ## Running as a Service
 

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -111,6 +111,11 @@ class HomeAssistantBridge:
         # from the main loop will attempt a fresh connect every _retry_interval seconds.
         self._last_retry_at = 0.0
         self._retry_interval = ha_config.get("retry_interval", 60)
+        # Clear current retained discovery payloads immediately before republishing
+        # them. This forces Home Assistant to reload payload field changes on
+        # service restart instead of requiring a manual MQTT integration reload.
+        self.clear_discovery_on_startup = ha_config.get("clear_discovery_on_startup", True)
+        self._clear_current_discovery = False
 
         # Deferred-discovery bookkeeping. Per-port DC-input entities
         # (dc5521, gx16mf1, gx16mf2) are only published the first time the
@@ -242,6 +247,7 @@ class HomeAssistantBridge:
         # Issue #49: reset before discovery so on_connect's subscribe loop
         # (which runs right after this) sees only currently-registered topics.
         self._command_topics = []
+        self._clear_current_discovery = bool(self.clear_discovery_on_startup)
         for device in self.devices:
             dk = device["device_key"]
             name = device["device_name"]
@@ -1066,6 +1072,7 @@ class HomeAssistantBridge:
 
             # Clear stale entities from previous versions that no longer apply to this model
             self._clear_stale_entities(dk)
+        self._clear_current_discovery = False
 
         log.info("Published Home Assistant discovery configs")
 
@@ -1147,6 +1154,8 @@ class HomeAssistantBridge:
         if category and "entity_category" not in config:
             config = {**config, "entity_category": category}
         topic = f"{self.discovery_prefix}/{component}/pecron_{dk}/{key}/config"
+        if self._clear_current_discovery:
+            self.client.publish(topic, "", qos=1, retain=True)
         self.client.publish(topic, json.dumps(config), qos=1, retain=True)
         self._published_topics.add(topic)
         # Issue #49: capture every command_topic this entity registers so the

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     pecron-monitor --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.12"
+__version__ = "0.7.13"
 
 import argparse
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pecron-monitor"
-version = "0.7.12"
+version = "0.7.13"
 description = "Monitor and control Pecron portable power stations from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -359,6 +359,7 @@ def setup_wizard(auto=False):
             "mqtt_user": ha_user,
             "mqtt_password": ha_pw,
             "discovery_prefix": "homeassistant",
+            "clear_discovery_on_startup": True,
         },
         "rule_state": {
             "initial_state": "default",

--- a/tests/unit/test_ha_discovery_republish.py
+++ b/tests/unit/test_ha_discovery_republish.py
@@ -1,0 +1,69 @@
+"""Tests for HA discovery clear-and-republish behavior."""
+
+import json
+from unittest.mock import MagicMock
+
+from ha_bridge import HomeAssistantBridge
+
+
+def _device(device_key="DEV1"):
+    return {
+        "device_key": device_key,
+        "device_name": "E1500LFP",
+        "controls": {
+            "battery_percentage": {},
+            "voltage": {},
+            "total_input_power": {},
+            "total_output_power": {},
+            "ac_switch_hm": {},
+            "dc_switch_hm": {},
+            "ups_status_hm": {},
+        },
+    }
+
+
+def _bridge(clear=True):
+    bridge = HomeAssistantBridge(
+        {"discovery_prefix": "homeassistant", "clear_discovery_on_startup": clear},
+        devices=[_device()],
+    )
+    bridge.client = MagicMock()
+    bridge._connected = True
+    return bridge
+
+
+def test_publish_discovery_clears_current_topic_before_republish():
+    bridge = _bridge(clear=True)
+
+    bridge._publish_discovery()
+
+    topic = "homeassistant/sensor/pecron_DEV1/battery/config"
+    calls = [call.args for call in bridge.client.publish.call_args_list if call.args[0] == topic]
+    assert len(calls) >= 2
+    assert calls[0] == (topic, "")
+    payload = json.loads(calls[1][1])
+    assert payload["unique_id"] == "pecron_DEV1_battery"
+
+
+def test_republished_config_topics_remain_tracked_not_stale_cleared():
+    bridge = _bridge(clear=True)
+
+    bridge._publish_discovery()
+
+    topic = "homeassistant/sensor/pecron_DEV1/battery/config"
+    assert topic in bridge._published_topics
+    # Exactly two publishes to a current topic: explicit clear, then new config.
+    # _clear_stale_entities must not clear it a third time as stale.
+    calls = [call.args for call in bridge.client.publish.call_args_list if call.args[0] == topic]
+    assert len(calls) == 2
+
+
+def test_clear_discovery_can_be_disabled_for_legacy_behavior():
+    bridge = _bridge(clear=False)
+
+    bridge._publish_discovery()
+
+    topic = "homeassistant/sensor/pecron_DEV1/battery/config"
+    calls = [call.args for call in bridge.client.publish.call_args_list if call.args[0] == topic]
+    assert len(calls) == 1
+    assert calls[0][1] != ""


### PR DESCRIPTION
## Summary
- release v0.7.13 with HA discovery clear-and-republish behavior
- clear each current retained discovery topic immediately before republishing on startup/reconnect
- add `homeassistant.clear_discovery_on_startup` escape hatch for previous publish-only behavior
- document the new behavior and setup-wizard config

## Verification
- python3 -m pytest tests/unit/test_ha_discovery_republish.py tests/unit/test_command_subscriptions.py tests/unit/test_ghost_suppression.py -q
- python3 -m ruff check .
- python3 -m ruff format --check .
- python3 -m py_compile pecron_monitor.py local_transport.py
- python3 -m pytest -q --cov=. --cov-report=term-missing

Project-board item: clear-and-republish HA discovery on startup so payload field updates apply without manual MQTT integration reload