### PR TITLE
Release v0.7.14 publish valid Home Assistant sensor categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to pecron-monitor are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
 
+## [0.7.14] - 2026-05-17
+
+### Fixed
+- **Home Assistant sensor discovery no longer emits invalid `entity_category: config` payloads**. Live HA testing showed config-category sensors are rejected by Home Assistant. Sensor entities that were previously classified as configuration are now published as diagnostic instead, keeping them out of the main view while preserving valid discovery payloads.
+
 ## [0.7.13] - 2026-05-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.7.13** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
+**v0.7.14** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -1151,6 +1151,11 @@ class HomeAssistantBridge:
         # Diagnostic sections. Applied here so every call site benefits without
         # 50 per-call-site edits.
         category = entity_category_for(key)
+        if component == "sensor" and category == "config":
+            # Home Assistant rejects config-category sensors. Keep these
+            # rarely-used settings out of the main view by downgrading them to
+            # diagnostic rather than publishing invalid discovery payloads.
+            category = "diagnostic"
         if category and "entity_category" not in config:
             config = {**config, "entity_category": category}
         topic = f"{self.discovery_prefix}/{component}/pecron_{dk}/{key}/config"

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     pecron-monitor --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.13"
+__version__ = "0.7.14"
 
 import argparse
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pecron-monitor"
-version = "0.7.13"
+version = "0.7.14"
 description = "Monitor and control Pecron portable power stations from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/unit/test_entity_categories.py
+++ b/tests/unit/test_entity_categories.py
@@ -144,6 +144,12 @@ class TestPubConfigInjectsCategory(unittest.TestCase):
         payload = self._last_published_payload(b)
         self.assertEqual(payload.get("entity_category"), "diagnostic")
 
+    def test_config_category_sensor_is_downgraded_to_diagnostic(self):
+        b = self._make_bridge()
+        b._pub_config("sensor", "DEADBEEF", "screen_brightness", {"name": "Brightness"})
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("entity_category"), "diagnostic")
+
     def test_explicit_category_in_payload_is_preserved(self):
         # If a call site already set entity_category explicitly, don't overwrite.
         b = self._make_bridge()


### PR DESCRIPTION
## Summary
- release v0.7.14 with HA sensor category compatibility fix
- live HA testing found `entity_category: config` is rejected for sensor entities
- sensor entities previously mapped to config are now published as diagnostic instead

## Verification
- local Home Assistant + Mosquitto stack consumed stale discovery payload without entity_category
- bridge clear+republish updated HA entity registry to `entity_category: diagnostic`
- python3 -m pytest tests/unit/test_entity_categories.py tests/unit/test_ha_discovery_republish.py -q
- python3 -m ruff check .
- python3 -m ruff format --check .
- python3 -m py_compile pecron_monitor.py local_transport.py
- python3 -m pytest -q --cov=. --cov-report=term-missing