### PR TITLE
fix: release v0.7.15 HA sensor state_class for Energy Dashboard (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to pecron-monitor are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
 
+## [0.7.15] - 2026-06-01
+
+### Fixed
+- **Home Assistant power/voltage/current/temperature/battery sensors now declare `state_class: measurement`** (#78). Without it, HA never recorded long-term statistics for these sensors, so they were display-only and could not feed the Energy Dashboard. They are now valid sources for a Riemann-sum integral helper (power W → energy kWh). Cumulative energy counters (`Total PV Energy`) keep `state_class: total_increasing`.
+
+### Added
+- **README "Energy Dashboard" section** (#78). Documents why Watt sensors can't be added to HA's Energy Dashboard directly and gives copy-paste Riemann-integral helper config to convert the AC/DC input/output power channels into Energy-Dashboard-eligible kWh sensors.
+
 ## [0.7.14] - 2026-05-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.7.14** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
+**v0.7.15** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 
@@ -254,6 +254,52 @@ republishing it on startup. This makes Home Assistant pick up discovery payload
 field changes after a service restart instead of requiring a manual MQTT
 integration reload. Set `clear_discovery_on_startup: false` if you need the old
 publish-only behavior.
+
+### Energy Dashboard
+
+The Pecron's input/output channels are published as **power** sensors (Watts):
+AC Input Power, AC Output Power, DC Input Power, DC Output Power. Home
+Assistant's **Energy Dashboard only accepts energy sensors (kWh)** — it cannot
+add a Watt sensor directly, which is why these don't show up in the dashboard's
+device picker even though the values look correct.
+
+The device firmware does not report cumulative kWh counters for these channels
+(only PV models expose a `Total PV Energy` sensor), so the fix is to let Home
+Assistant integrate power over time with its built-in **Riemann sum integral**
+helper. Each power sensor declares `state_class: measurement`, so HA records
+long-term statistics for it and can integrate it cleanly.
+
+**UI (easiest):** Settings → Devices & Services → **Helpers** → Create Helper →
+**Integration - Riemann sum integral**. Pick a Pecron power sensor as the source,
+set **Metric prefix = `k` (kilo)** and **Time unit = `h` (hours)**. The result is
+a kWh sensor you can add under Settings → Dashboards → **Energy**.
+
+**YAML** equivalent (use your own entity IDs):
+
+```yaml
+sensor:
+  - platform: integration
+    source: sensor.pecron_e1500lfp_ac_input_power   # grid charging in
+    name: Pecron AC Input Energy
+    unit_prefix: k       # -> kWh
+    unit_time: h
+    method: left
+    max_sub_interval: "00:05:00"   # advance even when power is steady
+  - platform: integration
+    source: sensor.pecron_e1500lfp_ac_output_power  # AC load out
+    name: Pecron AC Output Energy
+    unit_prefix: k
+    unit_time: h
+    method: left
+    max_sub_interval: "00:05:00"
+  # ...repeat for DC Input Power (solar) and DC Output Power
+```
+
+Then in the Energy Dashboard add the AC/DC **Output** energy sensors under
+"Individual devices", and the **Input** energy sensors (e.g. solar) under "Solar
+panels" or "Grid consumption" as appropriate. Note that resolution is bounded by
+`poll_interval` (the bridge only publishes new values that often), so the energy
+totals are approximate, not revenue-grade.
 
 ## Running as a Service
 

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -94,6 +94,22 @@ _DIAGNOSTIC_PREFIXES = ("pack_",)
 # at their call site instead.
 _MEASUREMENT_DEVICE_CLASSES = frozenset({"power", "voltage", "current", "temperature", "battery"})
 
+# Issue #78 review: sensor keys that carry a numeric device_class but whose state
+# publish_state decodes to a STRING label, not a number. These are the WB12200
+# charge/discharge limits -> "12.8V" / "60A" via WB_*_LABELS. A numeric
+# state_class on a string state is invalid in HA, so they're excluded from the
+# injection below. Genuine numeric config sensors (e.g. ac_output_voltage) are
+# NOT in this set and still get state_class. Keep in sync with the label decoder
+# (_wb_enum_fields) in publish_state.
+_LABEL_SENSOR_KEYS = frozenset(
+    {
+        "charging_limit_voltage",
+        "discharge_limit_voltage",
+        "charging_current_limit",
+        "discharge_current_limit",
+    }
+)
+
 
 def entity_category_for(key: str):
     """Return the HA entity_category ('config' / 'diagnostic') for an entity key,
@@ -1161,7 +1177,6 @@ class HomeAssistantBridge:
         # Diagnostic sections. Applied here so every call site benefits without
         # 50 per-call-site edits.
         category = entity_category_for(key)
-        original_category = category
         if component == "sensor" and category == "config":
             # Home Assistant rejects config-category sensors. Keep these
             # rarely-used settings out of the main view by downgrading them to
@@ -1173,15 +1188,12 @@ class HomeAssistantBridge:
         # state_class=measurement so HA records long-term statistics for them.
         # Applied centrally so every numeric sensor benefits without per-call-site
         # edits. Call sites that set state_class explicitly (e.g. total_energy =>
-        # total_increasing) are left untouched. Config-category entities are
-        # excluded even when they carry a numeric device_class: they are
-        # settings/knobs, and some (the WB12200 charge/discharge limits) decode
-        # to string labels like "12.8V" / "60A" in publish_state, which would be
-        # invalid under a numeric state_class. Check the pre-downgrade category
-        # since config sensors are republished as diagnostic above.
+        # total_increasing) are left untouched. _LABEL_SENSOR_KEYS are excluded:
+        # they carry a numeric device_class but publish string labels, invalid
+        # under a numeric state_class.
         if (
             component == "sensor"
-            and original_category != "config"
+            and key not in _LABEL_SENSOR_KEYS
             and "state_class" not in config
             and config.get("device_class") in _MEASUREMENT_DEVICE_CLASSES
         ):

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -1161,6 +1161,7 @@ class HomeAssistantBridge:
         # Diagnostic sections. Applied here so every call site benefits without
         # 50 per-call-site edits.
         category = entity_category_for(key)
+        original_category = category
         if component == "sensor" and category == "config":
             # Home Assistant rejects config-category sensors. Keep these
             # rarely-used settings out of the main view by downgrading them to
@@ -1172,9 +1173,15 @@ class HomeAssistantBridge:
         # state_class=measurement so HA records long-term statistics for them.
         # Applied centrally so every numeric sensor benefits without per-call-site
         # edits. Call sites that set state_class explicitly (e.g. total_energy =>
-        # total_increasing) are left untouched.
+        # total_increasing) are left untouched. Config-category entities are
+        # excluded even when they carry a numeric device_class: they are
+        # settings/knobs, and some (the WB12200 charge/discharge limits) decode
+        # to string labels like "12.8V" / "60A" in publish_state, which would be
+        # invalid under a numeric state_class. Check the pre-downgrade category
+        # since config sensors are republished as diagnostic above.
         if (
             component == "sensor"
+            and original_category != "config"
             and "state_class" not in config
             and config.get("device_class") in _MEASUREMENT_DEVICE_CLASSES
         ):

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -85,6 +85,16 @@ ENTITY_CATEGORIES = {
 _DIAGNOSTIC_PREFIXES = ("pack_",)
 
 
+# Issue #78: sensor device_classes whose readings are instantaneous point-in-time
+# measurements. HA only records long-term statistics for numeric sensors that
+# declare a state_class, so without this these sensors are display-only — they
+# never appear in history statistics and can't feed the Energy Dashboard via a
+# Riemann-sum integral helper (power W -> energy kWh). The `energy` device_class
+# is intentionally excluded: cumulative counters set state_class=total_increasing
+# at their call site instead.
+_MEASUREMENT_DEVICE_CLASSES = frozenset({"power", "voltage", "current", "temperature", "battery"})
+
+
 def entity_category_for(key: str):
     """Return the HA entity_category ('config' / 'diagnostic') for an entity key,
     or None if the entity should stay in the main device view."""
@@ -1158,6 +1168,17 @@ class HomeAssistantBridge:
             category = "diagnostic"
         if category and "entity_category" not in config:
             config = {**config, "entity_category": category}
+        # Issue #78: tag instantaneous measurement sensors with
+        # state_class=measurement so HA records long-term statistics for them.
+        # Applied centrally so every numeric sensor benefits without per-call-site
+        # edits. Call sites that set state_class explicitly (e.g. total_energy =>
+        # total_increasing) are left untouched.
+        if (
+            component == "sensor"
+            and "state_class" not in config
+            and config.get("device_class") in _MEASUREMENT_DEVICE_CLASSES
+        ):
+            config = {**config, "state_class": "measurement"}
         topic = f"{self.discovery_prefix}/{component}/pecron_{dk}/{key}/config"
         if self._clear_current_discovery:
             self.client.publish(topic, "", qos=1, retain=True)

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     pecron-monitor --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.14"
+__version__ = "0.7.15"
 
 import argparse
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pecron-monitor"
-version = "0.7.14"
+version = "0.7.15"
 description = "Monitor and control Pecron portable power stations from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/unit/test_state_class.py
+++ b/tests/unit/test_state_class.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Tests for HA state_class injection on discovery payloads (issue #78).
+
+Home Assistant only records long-term statistics for numeric sensors that
+declare a state_class. Without it, power/voltage/current readings are
+display-only and can't feed the Energy Dashboard via a Riemann-sum integral
+helper. _pub_config() injects state_class=measurement for instantaneous
+measurement sensors, while leaving cumulative energy counters (which set
+state_class=total_increasing at their call site) untouched.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock
+
+# sys.path + paho mocking are handled globally by tests/conftest.py
+from ha_bridge import HomeAssistantBridge, _MEASUREMENT_DEVICE_CLASSES
+
+
+class TestPubConfigInjectsStateClass(unittest.TestCase):
+    def _make_bridge(self):
+        b = HomeAssistantBridge({"discovery_prefix": "homeassistant"}, devices=[])
+        b.client = MagicMock()
+        b._published_topics = set()
+        return b
+
+    def _last_published_payload(self, bridge):
+        args, _ = bridge.client.publish.call_args
+        return json.loads(args[1])
+
+    def test_power_sensor_gets_measurement(self):
+        b = self._make_bridge()
+        b._pub_config(
+            "sensor", "DEADBEEF", "ac_output", {"name": "AC Output Power", "device_class": "power"}
+        )
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("state_class"), "measurement")
+
+    def test_all_measurement_device_classes_get_tagged(self):
+        for dev_class in _MEASUREMENT_DEVICE_CLASSES:
+            b = self._make_bridge()
+            b._pub_config(
+                "sensor", "DEADBEEF", "some_key", {"name": "X", "device_class": dev_class}
+            )
+            payload = self._last_published_payload(b)
+            self.assertEqual(
+                payload.get("state_class"),
+                "measurement",
+                f"device_class {dev_class!r} should get state_class=measurement",
+            )
+
+    def test_energy_sensor_is_not_overwritten(self):
+        # total_energy sets total_increasing at its call site; we must not clobber it.
+        b = self._make_bridge()
+        b._pub_config(
+            "sensor",
+            "DEADBEEF",
+            "total_energy",
+            {
+                "name": "Total PV Energy",
+                "device_class": "energy",
+                "state_class": "total_increasing",
+                "unit_of_measurement": "kWh",
+            },
+        )
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("state_class"), "total_increasing")
+
+    def test_diagnostic_power_sensor_still_gets_measurement(self):
+        # ac_input/dc_input are diagnostic-category but still real measurements;
+        # they must get state_class so a Riemann integral can run on them.
+        b = self._make_bridge()
+        b._pub_config(
+            "sensor", "DEADBEEF", "ac_input", {"name": "AC Input Power", "device_class": "power"}
+        )
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("entity_category"), "diagnostic")
+        self.assertEqual(payload.get("state_class"), "measurement")
+
+    def test_non_measurement_device_class_untouched(self):
+        b = self._make_bridge()
+        b._pub_config(
+            "sensor",
+            "DEADBEEF",
+            "device_status",
+            {"name": "Device Status", "device_class": "enum"},
+        )
+        payload = self._last_published_payload(b)
+        self.assertNotIn("state_class", payload)
+
+    def test_sensor_without_device_class_untouched(self):
+        # e.g. AC power factor / frequency entities carry no device_class.
+        b = self._make_bridge()
+        b._pub_config("sensor", "DEADBEEF", "ac_output_pf", {"name": "AC Power Factor"})
+        payload = self._last_published_payload(b)
+        self.assertNotIn("state_class", payload)
+
+    def test_switch_component_untouched(self):
+        # state_class is a sensor-only concept; switches must never get it.
+        b = self._make_bridge()
+        b._pub_config("switch", "DEADBEEF", "ac", {"name": "AC Output", "device_class": "outlet"})
+        payload = self._last_published_payload(b)
+        self.assertNotIn("state_class", payload)
+
+    def test_explicit_state_class_in_payload_is_preserved(self):
+        b = self._make_bridge()
+        b._pub_config(
+            "sensor",
+            "DEADBEEF",
+            "voltage",
+            {"name": "Voltage", "device_class": "voltage", "state_class": "total"},
+        )
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("state_class"), "total")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/unit/test_state_class.py
+++ b/tests/unit/test_state_class.py
@@ -113,6 +113,33 @@ class TestPubConfigInjectsStateClass(unittest.TestCase):
         payload = self._last_published_payload(b)
         self.assertEqual(payload.get("state_class"), "total")
 
+    def test_wb12200_limit_sensors_do_not_get_state_class(self):
+        # Regression for #78 review: these config-category sensors carry a numeric
+        # device_class (voltage/current) but publish_state decodes them to string
+        # labels like "12.8V" / "60A". A numeric state_class on a string state is
+        # invalid in HA, so they must be excluded. They are also downgraded from
+        # config -> diagnostic (HA rejects config-category sensors).
+        cases = [
+            ("charging_limit_voltage", "voltage"),
+            ("discharge_limit_voltage", "voltage"),
+            ("charging_current_limit", "current"),
+            ("discharge_current_limit", "current"),
+        ]
+        for key, dev_class in cases:
+            b = self._make_bridge()
+            b._pub_config("sensor", "DEADBEEF", key, {"name": key, "device_class": dev_class})
+            payload = self._last_published_payload(b)
+            self.assertNotIn(
+                "state_class",
+                payload,
+                f"config sensor {key!r} (label state) must not get state_class",
+            )
+            self.assertEqual(
+                payload.get("entity_category"),
+                "diagnostic",
+                f"{key!r} should be downgraded config -> diagnostic",
+            )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/unit/test_state_class.py
+++ b/tests/unit/test_state_class.py
@@ -140,6 +140,26 @@ class TestPubConfigInjectsStateClass(unittest.TestCase):
                 f"{key!r} should be downgraded config -> diagnostic",
             )
 
+    def test_numeric_config_sensor_still_gets_state_class(self):
+        # Regression for #78 review (round 2): ac_output_voltage is config-category
+        # (downgraded to diagnostic) but it's a genuine numeric voltage reading, so
+        # the exclusion must NOT be category-wide -- only the label-backed keys are
+        # excluded. ac_output_voltage must keep state_class=measurement.
+        b = self._make_bridge()
+        b._pub_config(
+            "sensor",
+            "DEADBEEF",
+            "ac_output_voltage",
+            {"name": "AC Output Voltage", "device_class": "voltage"},
+        )
+        payload = self._last_published_payload(b)
+        self.assertEqual(payload.get("entity_category"), "diagnostic")
+        self.assertEqual(
+            payload.get("state_class"),
+            "measurement",
+            "numeric config sensor ac_output_voltage must keep state_class",
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What
Home Assistant power/voltage/current/temperature/battery sensors now declare `state_class: measurement`. Previously only `total_energy` had a state_class, so every other numeric sensor was display-only — HA recorded no long-term statistics, and they couldn't feed the Energy Dashboard via a Riemann-sum integral helper.

Closes #78. Turnkey energy sensors (zero-helper) tracked separately as #79.

## Root cause (verified against the device TSL)
HA's Energy Dashboard only accepts energy (kWh) sensors (`device_class: energy` + `state_class: total/total_increasing`). The four channels users want (AC/DC in/out) are **power** (W) sensors, which HA won't accept directly. The Pecron cloud TSL confirms the hardware exposes **no per-channel kWh counters** (only `total_energy` PV on some models), so energy must be integrated from power — HA's Riemann integral helper is the supported path, and it needs the source to declare `state_class`.

## Changes
- `ha_bridge.py`: inject `state_class: "measurement"` centrally in `_pub_config` for `_MEASUREMENT_DEVICE_CLASSES` (power/voltage/current/temperature/battery). Energy keeps `total_increasing`. Label-backed config sensors (`_LABEL_SENSOR_KEYS`: the four WB12200 charge/discharge limits, which decode to strings like `"12.8V"`/`"60A"`) are excluded; genuine numeric config readings like `ac_output_voltage` still get it.
- `tests/unit/test_state_class.py`: 10 tests (injection, energy-not-clobbered, diagnostic sensors, switches, no-device_class, explicit override, WB-limit exclusion, ac_output_voltage retention).
- `README.md`: "Energy Dashboard" section with copy-paste Riemann integral config.
- v0.7.15 bump (CHANGELOG, `__version__`, pyproject).

## Verification (live hardware + HA)
Deployed to the live host (E1500LFP → mosquitto → HA in Docker), restarted the service across all three iterations:
- All six power sensors publish `state_class=measurement`; HA records statistics (`statistics_meta` rows appeared where absent before — AC Input mean 958.6 W).
- `ac_output_voltage` (config + numeric) publishes `state_class` and HA records it as numeric (`115 V`); the four WB limit keys are excluded.
- Existing `total_pv_energy` (`has_sum=1`, kWh) confirms the energy→Energy-Dashboard pipeline works on this HA.

## Checks
`ruff format --check` ✅ · `ruff check` ✅ · `pytest` **328 passed / 6 skipped** ✅ · version consistency ✅