### PR TITLE
feat: release v0.7.17 multiple named rule-state variables (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to pecron-monitor are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
 
+## [0.7.17] - 2026-06-01
+
+### Added
+- **Multiple named rule-state variables** (#56). The rules engine state can now be a map of independent named variables instead of a single string. Make `rule_state.initial_state` a map (e.g. `{mode: off, charge: idle}`), gate rules with `state: {mode: peak}` or `states: {mode: [peak, shoulder]}` (every named variable must match), and update selected variables with `set_state: {mode: peak}` (others unchanged). `run_command` payloads now include a `states` map alongside the existing `state` string.
+
+### Changed
+- Legacy single-string rule state is unchanged: it lives under a reserved `default` variable, so existing `initial_state`/`state`/`states`/`set_state` string configs and persisted state files keep working. The persisted format moves to `{"states": {...}}`; old `{"state": "..."}` files are read and migrated on next write.
+
 ## [0.7.16] - 2026-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pecron Battery Monitor
 
-**v0.7.16** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
+**v0.7.17** · [Changelog](CHANGELOG.md) · [Latest release](https://github.com/attractify-logan/pecron-monitor/releases/latest) · [Project board](https://github.com/users/attractify-logan/projects/1)
 
 Monitor and control Pecron portable power stations from the command line — no phone app required.
 
@@ -178,8 +178,8 @@ restore_outputs_after_shutdown:
 | `schedule` | `"00:00"` — fires only on an exact `HH:MM` poll |
 | `schedule_between` | `["17:00", "21:00"]` — within a daily window; wraps midnight (`["22:00","06:00"]`) |
 | `init` | `true` — fires once when the service starts |
-| `state` | `"normal"` — only evaluate this rule in one state |
-| `states` | `["normal", "peak"]` — only evaluate this rule in any listed state |
+| `state` | `"normal"` — only in this state; or `{mode: peak, charge: armed}` to require named variables |
+| `states` | `["normal", "peak"]` — any listed state; or `{mode: [peak, shoulder]}` per named variable |
 
 **Multiple conditions in one rule are ANDed** — every trigger key present must
 hold for the rule to fire (e.g. `voltage_below` + `output_power_below` to charge
@@ -191,10 +191,17 @@ skip.
 
 Actions: `set_ac`, `set_dc`, `set_ups` (true/false), `set_state`, `run_command`
 
-Rule state is a single persisted string. Set the initial value with
-`rule_state.initial_state`; by default state is saved at
-`~/.pecron-monitor-rules.json` and survives service restarts. Use `set_state` to
-transition between states.
+Rule state is persisted at `~/.pecron-monitor-rules.json` (override with
+`rule_state.path`) and survives service restarts. The simplest form is a single
+string state: set `rule_state.initial_state: normal`, gate rules with
+`state`/`states`, and transition with `set_state: low`.
+
+For independent concerns, use **named state variables**: make `initial_state` a
+map (e.g. `{mode: off, charge: idle}`), gate with `state: {mode: peak}` /
+`states: {mode: [peak, shoulder]}` (every named variable must match), and update
+selected variables with `set_state: {mode: peak}` (others are left unchanged).
+Legacy single-string state lives under the reserved `default` variable, so old
+configs and state files keep working unchanged.
 
 `run_command` executes an external command without a shell. Provide either an
 argv list or a string that can be split like a shell command. The monitor sends

--- a/monitor.py
+++ b/monitor.py
@@ -123,7 +123,7 @@ class PecronMonitor:
         # Automation rules
         self.rules = config.get("rules", [])
         self.rule_state_config = config.get("rule_state", {}) or {}
-        self.rule_state = self._load_rule_state()
+        self.rule_states = self._load_rule_states()
         self._init_rules_ran = False
 
         self._mqtt_connect_failures = 0
@@ -1207,14 +1207,25 @@ class PecronMonitor:
             return Path(configured).expanduser()
         return Path.home() / ".pecron-monitor-rules.json"
 
-    def _initial_rule_state(self) -> str:
-        """Return configured initial rule state."""
-        return str(self.rule_state_config.get("initial_state", "default"))
+    _DEFAULT_STATE_VAR = "default"
 
-    def _load_rule_state(self) -> str:
-        """Load persisted rule state, falling back to the configured initial state."""
+    def _initial_rule_states(self) -> dict:
+        """Configured initial state variables as a name->value dict.
+        `initial_state` may be a plain string (the single `default` variable,
+        legacy) or a dict of named variables."""
+        initial = self.rule_state_config.get("initial_state")
+        if isinstance(initial, dict):
+            return {str(k): str(v) for k, v in initial.items()}
+        if initial is None:
+            return {self._DEFAULT_STATE_VAR: "default"}
+        return {self._DEFAULT_STATE_VAR: str(initial)}
+
+    def _load_rule_states(self) -> dict:
+        """Load persisted state variables, falling back to the configured initial
+        values. Reads both the multi-variable `{"states": {...}}` format and the
+        legacy single-state `{"state": "..."}` format."""
         path = self._rule_state_path()
-        fallback = self._initial_rule_state()
+        fallback = self._initial_rule_states()
         if not path.exists():
             return fallback
         try:
@@ -1223,11 +1234,18 @@ class PecronMonitor:
         except (OSError, json.JSONDecodeError) as e:
             log.warning("Could not load rule state from %s: %s", path, e)
             return fallback
-        state = data.get("state") if isinstance(data, dict) else None
-        return str(state) if state else fallback
+        if not isinstance(data, dict):
+            return fallback
+        states = data.get("states")
+        if isinstance(states, dict) and states:
+            return {str(k): str(v) for k, v in states.items()}
+        legacy = data.get("state")  # pre-multivar single-state format
+        if legacy:
+            return {self._DEFAULT_STATE_VAR: str(legacy)}
+        return fallback
 
-    def _save_rule_state(self) -> None:
-        """Persist current rule state atomically."""
+    def _save_rule_states(self) -> None:
+        """Persist current state variables atomically."""
         path = self._rule_state_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp_name = tempfile.mkstemp(prefix=".pecron-rules-", dir=str(path.parent))
@@ -1235,7 +1253,7 @@ class PecronMonitor:
         try:
             with os.fdopen(fd, "w") as f:
                 json.dump(
-                    {"state": self.rule_state, "updated_at": datetime.utcnow().isoformat()},
+                    {"states": self.rule_states, "updated_at": datetime.utcnow().isoformat()},
                     f,
                 )
                 f.write("\n")
@@ -1247,26 +1265,45 @@ class PecronMonitor:
                 pass
             raise
 
-    def _set_rule_state(self, state: str) -> None:
-        """Change and persist the single rule engine state."""
-        new_state = str(state)
-        if new_state == self.rule_state:
-            return
-        old_state = self.rule_state
-        self.rule_state = new_state
-        self._save_rule_state()
-        log.info("Rule state changed: %s -> %s", old_state, new_state)
+    def _set_rule_states(self, updates) -> None:
+        """Apply one or more name->value state changes and persist if anything
+        changed. A bare string updates the single `default` variable (legacy)."""
+        if not isinstance(updates, dict):
+            updates = {self._DEFAULT_STATE_VAR: updates}
+        changed = {}
+        for name, value in updates.items():
+            name, value = str(name), str(value)
+            if self.rule_states.get(name) != value:
+                self.rule_states[name] = value
+                changed[name] = value
+        if changed:
+            self._save_rule_states()
+            log.info("Rule state changed: %s", changed)
 
     def _rule_state_matches(self, condition: dict) -> bool:
-        """Return whether current state satisfies a rule condition's state gate."""
+        """Whether the current state variables satisfy a rule's state gate.
+        `state`/`states` accept the legacy single-variable string/list, or a
+        {variable: value} / {variable: [values]} dict for named variables (every
+        named variable must match)."""
         if "state" in condition:
-            return self.rule_state == str(condition["state"])
+            spec = condition["state"]
+            if isinstance(spec, dict):
+                return all(self.rule_states.get(str(k)) == str(v) for k, v in spec.items())
+            return self.rule_states.get(self._DEFAULT_STATE_VAR) == str(spec)
         states = condition.get("states")
         if states is None:
             return True
+        if isinstance(states, dict):
+            for name, allowed in states.items():
+                allowed_set = (
+                    {str(allowed)} if isinstance(allowed, str) else {str(a) for a in allowed}
+                )
+                if self.rule_states.get(str(name)) not in allowed_set:
+                    return False
+            return True
         if isinstance(states, str):
-            return self.rule_state == states
-        return self.rule_state in {str(state) for state in states}
+            return self.rule_states.get(self._DEFAULT_STATE_VAR) == states
+        return self.rule_states.get(self._DEFAULT_STATE_VAR) in {str(s) for s in states}
 
     def _run_rule_command(
         self,
@@ -1289,7 +1326,8 @@ class PecronMonitor:
 
         payload = {
             "rule": rule.get("name"),
-            "state": self.rule_state,
+            "state": self.rule_states.get(self._DEFAULT_STATE_VAR),
+            "states": dict(self.rule_states),
             "device_key": device_key,
             "target_device_key": target_device_key,
             "battery_percent": battery_pct,
@@ -1507,7 +1545,7 @@ class PecronMonitor:
                         )
 
                 if "set_state" in action:
-                    self._set_rule_state(action["set_state"])
+                    self._set_rule_states(action["set_state"])
                     log.info("Rule '%s': set state=%s", rule.get("name"), action["set_state"])
 
                 if "run_command" in action:

--- a/pecron_monitor.py
+++ b/pecron_monitor.py
@@ -20,7 +20,7 @@ Usage:
     pecron-monitor --homeassistant # Start with Home Assistant MQTT bridge
 """
 
-__version__ = "0.7.16"
+__version__ = "0.7.17"
 
 import argparse
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pecron-monitor"
-version = "0.7.16"
+version = "0.7.17"
 description = "Monitor and control Pecron portable power stations from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/unit/test_rules_compound.py
+++ b/tests/unit/test_rules_compound.py
@@ -141,7 +141,7 @@ def test_output_power_below_fires_on_genuine_zero():
 
 def test_state_gate_without_trigger_never_fires():
     monitor = _monitor_with_rule({"state": "peak"})
-    monitor.rule_state = "peak"
+    monitor.rule_states = {"default": "peak"}
     monitor._evaluate_rules("DK", {"voltage": 50.0, "total_output_power": 800}, 30)
     monitor.set_ac.assert_not_called()
 

--- a/tests/unit/test_rules_engine_state.py
+++ b/tests/unit/test_rules_engine_state.py
@@ -46,11 +46,11 @@ def test_rule_state_action_persists_and_new_monitor_loads_it(tmp_path):
 
     monitor._evaluate_rules("DK", {"battery_percentage": 40, "voltage": 52.0}, 40)
 
-    assert monitor.rule_state == "low"
+    assert monitor.rule_states["default"] == "low"
     state_file = tmp_path / "rules-state.json"
-    assert json.loads(state_file.read_text())["state"] == "low"
+    assert json.loads(state_file.read_text())["states"]["default"] == "low"
     reloaded = _make_monitor(tmp_path, [], initial_state="normal")
-    assert reloaded.rule_state == "low"
+    assert reloaded.rule_states["default"] == "low"
 
 
 def test_state_gate_prevents_rule_in_wrong_state(tmp_path):

--- a/tests/unit/test_rules_multivar.py
+++ b/tests/unit/test_rules_multivar.py
@@ -1,0 +1,144 @@
+"""Tests for multiple named rule-state variables (#56 stretch goal)."""
+
+import json
+import sys
+from unittest.mock import MagicMock
+
+from monitor import PecronMonitor
+
+
+def _make_monitor(tmp_path, rules, *, initial_state="default"):
+    config = {
+        "email": "test@example.com",
+        "password": "test",
+        "region": "na",
+        "devices": [],
+        "rule_state": {
+            "initial_state": initial_state,
+            "path": str(tmp_path / "rules-state.json"),
+        },
+        "rules": rules,
+    }
+    monitor = PecronMonitor(config)
+    monitor.devices = [
+        {
+            "device_key": "DK",
+            "device_name": "TestDevice",
+            "controls": {"ac_switch_hm": {}, "dc_switch_hm": {}, "ups_status_hm": {}},
+        }
+    ]
+    monitor.set_ac = MagicMock(return_value=True)
+    return monitor
+
+
+def _ac_rule(condition=None, action=None):
+    return {
+        "name": "r",
+        "condition": condition or {"battery_below": 50},
+        "action": action or {"set_ac": False},
+        "cooldown_minutes": 0,
+    }
+
+
+# --- initial state ----------------------------------------------------------
+
+
+def test_initial_state_dict_sets_named_vars(tmp_path):
+    m = _make_monitor(tmp_path, [], initial_state={"mode": "off", "charge": "idle"})
+    assert m.rule_states == {"mode": "off", "charge": "idle"}
+
+
+def test_legacy_string_initial_uses_default_var(tmp_path):
+    m = _make_monitor(tmp_path, [], initial_state="normal")
+    assert m.rule_states == {"default": "normal"}
+
+
+# --- state gate (dict: all named vars must match) ---------------------------
+
+
+def test_state_gate_dict_all_match_fires(tmp_path):
+    cond = {"state": {"mode": "peak", "charge": "armed"}, "battery_below": 50}
+    m = _make_monitor(tmp_path, [_ac_rule(cond)], initial_state={"mode": "peak", "charge": "armed"})
+    m._evaluate_rules("DK", {"voltage": 52.0}, 40)
+    m.set_ac.assert_called_once_with("DK", False)
+
+
+def test_state_gate_dict_one_mismatch_blocks(tmp_path):
+    cond = {"state": {"mode": "peak", "charge": "armed"}, "battery_below": 50}
+    m = _make_monitor(tmp_path, [_ac_rule(cond)], initial_state={"mode": "peak", "charge": "idle"})
+    m._evaluate_rules("DK", {"voltage": 52.0}, 40)
+    m.set_ac.assert_not_called()
+
+
+# --- states gate (dict: var -> allowed list) --------------------------------
+
+
+def test_states_gate_dict_member_fires(tmp_path):
+    cond = {"states": {"mode": ["peak", "shoulder"]}, "battery_below": 50}
+    m = _make_monitor(tmp_path, [_ac_rule(cond)], initial_state={"mode": "shoulder"})
+    m._evaluate_rules("DK", {"voltage": 52.0}, 40)
+    m.set_ac.assert_called_once_with("DK", False)
+
+
+def test_states_gate_dict_non_member_blocks(tmp_path):
+    cond = {"states": {"mode": ["peak", "shoulder"]}, "battery_below": 50}
+    m = _make_monitor(tmp_path, [_ac_rule(cond)], initial_state={"mode": "off"})
+    m._evaluate_rules("DK", {"voltage": 52.0}, 40)
+    m.set_ac.assert_not_called()
+
+
+# --- set_state (dict) -------------------------------------------------------
+
+
+def test_set_state_dict_persists_and_reloads(tmp_path):
+    rule = _ac_rule(action={"set_state": {"mode": "peak", "charge": "armed"}})
+    m = _make_monitor(tmp_path, [rule], initial_state={"mode": "off", "charge": "idle"})
+    m._evaluate_rules("DK", {"voltage": 52.0}, 40)
+    assert m.rule_states == {"mode": "peak", "charge": "armed"}
+    data = json.loads((tmp_path / "rules-state.json").read_text())
+    assert data["states"] == {"mode": "peak", "charge": "armed"}
+    reloaded = _make_monitor(tmp_path, [], initial_state={"mode": "off", "charge": "idle"})
+    assert reloaded.rule_states == {"mode": "peak", "charge": "armed"}
+
+
+def test_set_state_named_var_leaves_others_unchanged(tmp_path):
+    rule = _ac_rule(action={"set_state": {"mode": "on"}})
+    m = _make_monitor(tmp_path, [rule], initial_state={"mode": "off", "charge": "idle"})
+    m._evaluate_rules("DK", {"voltage": 52.0}, 40)
+    assert m.rule_states == {"mode": "on", "charge": "idle"}
+
+
+def test_legacy_string_set_state_updates_default_var(tmp_path):
+    rule = _ac_rule(action={"set_state": "low"})
+    m = _make_monitor(tmp_path, [rule], initial_state="normal")
+    m._evaluate_rules("DK", {"voltage": 52.0}, 40)
+    assert m.rule_states == {"default": "low"}
+
+
+# --- persistence migration --------------------------------------------------
+
+
+def test_legacy_persisted_state_file_is_migrated(tmp_path):
+    (tmp_path / "rules-state.json").write_text(json.dumps({"state": "low", "updated_at": "x"}))
+    m = _make_monitor(tmp_path, [], initial_state="normal")
+    assert m.rule_states == {"default": "low"}
+
+
+# --- run_command payload ----------------------------------------------------
+
+
+def test_run_command_payload_includes_states_dict(tmp_path):
+    script = tmp_path / "cap.py"
+    output = tmp_path / "out.json"
+    script.write_text(
+        "import json, pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text(json.dumps(json.load(sys.stdin)))\n"
+    )
+    rule = _ac_rule(
+        action={"run_command": [sys.executable, str(script), str(output)], "timeout_seconds": 5}
+    )
+    m = _make_monitor(tmp_path, [rule], initial_state={"mode": "peak", "charge": "armed"})
+    m._evaluate_rules("DK", {"voltage": 52.0}, 40)
+    payload = json.loads(output.read_text())
+    assert payload["states"] == {"mode": "peak", "charge": "armed"}
+    assert payload["state"] is None  # no `default` variable configured


### PR DESCRIPTION
## What
Implements the last open item on #56 — Bruce's **stretch goal: multiple named state variables**. The rules engine state can now be a map of independent named variables instead of a single string.

```yaml
rule_state:
  initial_state: { mode: off, charge: idle }   # named variables

rules:
  - name: "Arm charging in peak window"
    condition: { schedule_between: ["17:00","21:00"], state: { mode: peak } }
    action: { set_state: { charge: armed } }    # updates only `charge`
  - name: "Charge when low and load light, if armed"
    condition: { state: { charge: armed }, voltage_below: 50.5, output_power_below: 2000 }
    action: { set_ups: true }
```

## Design — one model, backward compatible
- Internally state is a single `name -> value` dict (`self.rule_states`).
- **Legacy single-string state lives under a reserved `default` variable**, so every existing config keeps working unchanged:
  - `initial_state: normal` → `{default: normal}`
  - `state: normal` / `states: [normal, peak]` → gate on `default`
  - `set_state: low` → set `default`
- **Named-variable syntax** (new): `initial_state: {mode: off}`, `state: {mode: peak, charge: armed}` (all must match), `states: {mode: [peak, shoulder]}`, `set_state: {mode: peak}` (leaves other variables unchanged).
- **Persistence**: format moves to `{"states": {...}}`; old `{"state": "..."}` files are read and migrated on next write (no data loss for existing deployments like kim-pine).
- `run_command` payloads now include a `states` map alongside the existing `state` string (default variable), so external scripts keep working.

## Changes
- `monitor.py`: `_initial_rule_states`/`_load_rule_states`/`_save_rule_states`/`_set_rule_states` and a dict-aware `_rule_state_matches` replace the single-string versions; `_DEFAULT_STATE_VAR` reserved key.
- `tests/unit/test_rules_multivar.py`: 11 tests (named-var init, state/states dict gates, set_state dict + isolation + persistence reload, legacy string + legacy file migration, run_command `states`). Existing rules tests updated for the dict model.
- `README.md` rules/state docs; v0.7.17 bump.

## Checks
`ruff format --check` ✅ · `ruff check` ✅ · `pytest` **363 passed / 6 skipped** ✅ · version consistency ✅

This completes the multi-variable-state stretch — the last tracked item on #56 (arbitrary-Python-from-config remains intentionally declined). Hardware verification held for your review per the usual flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)