### PR TITLE
fix: E3800LFP local TCP telemetry timeout + false-positive completeness check

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -86,6 +86,20 @@ MODEL_BEHAVIOR: dict[str, dict[str, bool]] = {
     "E3600LFP": {"high_freq_effective": False},
 }
 
+# Local TCP inter-packet read timeout (seconds), per model. E3600/E3800 split
+# telemetry across 3-4 TTLV packets with up to ~3-4s gaps between them (issue
+# #15). The global default below was tuned to 3.0s in issue #6 for models that
+# only ever send a single packet, but that's too tight for E3600/E3800 -- it
+# cuts the read off before the packet carrying real voltage/temp arrives,
+# leaving only settings data (issue #84). Unlisted models use the default.
+LOCAL_READ_TIMEOUT_DEFAULT = 3.0
+LOCAL_READ_TIMEOUT_OVERRIDES: dict[str, float] = {
+    "E3600": 5.0,
+    "E3600LFP": 5.0,
+    "E3800": 5.0,
+    "E3800LFP": 5.0,
+}
+
 # ---------------------------------------------------------------------------
 # Data point IDs (from Quectel TSL — Thing Specification Language)
 # These are universal for each Pecron product model.

--- a/local_transport.py
+++ b/local_transport.py
@@ -331,12 +331,17 @@ class LocalTransport:
         timeout: float = 10.0,
         device_key: str = None,
         controls: dict = None,
+        multi_packet_timeout: float = 3.0,
     ):
         self.device_ip = device_ip
         self.device_port = 6607
         self.auth_key = base64.b64decode(auth_key_b64)
         self.auth_key_b64 = auth_key_b64
         self.timeout = timeout
+        # Per-packet timeout while collecting a multi-packet read_status()
+        # response. Some models (E3600/E3800) need longer gaps between
+        # packets than others — see LOCAL_READ_TIMEOUT_OVERRIDES (issue #84).
+        self.multi_packet_timeout = multi_packet_timeout
 
         self._sock = None
         self._iv = None  # Set after handshake
@@ -528,10 +533,11 @@ class LocalTransport:
                 packets_read = 0
                 max_packets = 10  # Safety limit
 
-                # Temporarily reduce socket timeout for multi-packet reads
-                # E3800/E3600 can take 2-3 seconds between packets
+                # Temporarily reduce socket timeout for multi-packet reads.
+                # Per-model: E3800/E3600 can take 3-4 seconds between packets
+                # (see self.multi_packet_timeout / LOCAL_READ_TIMEOUT_OVERRIDES).
                 original_timeout = self._sock.gettimeout()
-                self._sock.settimeout(3.0)
+                self._sock.settimeout(self.multi_packet_timeout)
 
                 while packets_read < max_packets:
                     try:
@@ -579,7 +585,7 @@ class LocalTransport:
                         # Retry read command
                         pkt = _ttlv_build_packet(0x0011, b"", self._next_pid())
                         self._sock.sendall(pkt)
-                        self._sock.settimeout(3.0)
+                        self._sock.settimeout(self.multi_packet_timeout)
                         all_fields = []
                         packets_read = 0
                         while packets_read < max_packets:

--- a/monitor.py
+++ b/monitor.py
@@ -34,6 +34,8 @@ from constants import (
     SENSOR_FIELDS,
     BATTERY_CAPACITY_WH,
     MODEL_BEHAVIOR,
+    LOCAL_READ_TIMEOUT_DEFAULT,
+    LOCAL_READ_TIMEOUT_OVERRIDES,
 )
 from cloud_api import login, resolve_devices, get_device_properties_rest, set_device_property_rest
 from protocol import build_ttlv_read, build_ttlv_write_bool, build_ttlv_write_enum
@@ -358,6 +360,7 @@ class PecronMonitor:
                         auth_key,
                         device_key=dk,
                         controls=device.get("controls", DEFAULT_CONTROLS),
+                        multi_packet_timeout=self._local_read_timeout(device),
                     )
                     log.info("Local transport configured for %s @ %s", dk, lan_ip)
                 except Exception as e:
@@ -444,11 +447,13 @@ class PecronMonitor:
                     # Re-create transport with new IP
                     from local_transport import LocalTransport
 
+                    rediscovered_device = self._find_device(device_key)
                     self.local_transports[device_key] = LocalTransport(
                         new_ip,
                         cfg["auth_key"],
                         device_key=device_key,
-                        controls=self._find_device(device_key).get("controls", DEFAULT_CONTROLS),
+                        controls=rediscovered_device.get("controls", DEFAULT_CONTROLS),
+                        multi_packet_timeout=self._local_read_timeout(rediscovered_device),
                     )
                     return True
                 else:
@@ -563,9 +568,17 @@ class PecronMonitor:
         if kv.get("total_input_power", 0) > 0 or kv.get("total_output_power", 0) > 0:
             return True
 
-        # Check for battery_percentage at top level (E3600/E3800 MQTT telemetry packets)
+        # battery_percentage alone is NOT enough (issue #84): E3600/E3800
+        # settings-only payloads also include battery_percentage, so on its
+        # own it can't distinguish "complete telemetry" from "just settings".
+        # Require it alongside a flat temperature field (battery_temp etc.,
+        # used by E300LFP/E3800-style flat payloads per SENSOR_FIELDS) as
+        # corroborating evidence that a real telemetry packet arrived.
         battery_pct = kv.get("battery_percentage")
-        if battery_pct is not None:
+        has_flat_temp = any(
+            field in kv for field in ("battery_temp", "charging_plate_temp", "inverter_temp")
+        )
+        if battery_pct is not None and has_flat_temp:
             try:
                 if int(float(battery_pct)) >= 0:
                     return True
@@ -2192,6 +2205,13 @@ class PecronMonitor:
         (issue #14: E3600LFP ignores the setting; don't waste cloud requests)."""
         name = device.get("device_name") or device.get("product_name") or ""
         return MODEL_BEHAVIOR.get(name, {}).get("high_freq_effective", True)
+
+    @staticmethod
+    def _local_read_timeout(device: dict) -> float:
+        """Per-model inter-packet timeout for local TCP multi-packet reads
+        (issue #84: E3600/E3800 need longer gaps than the 3.0s global default)."""
+        name = device.get("device_name") or device.get("product_name") or ""
+        return LOCAL_READ_TIMEOUT_OVERRIDES.get(name, LOCAL_READ_TIMEOUT_DEFAULT)
 
     def _enable_high_freq_reporting(self, stagger: float = 0):
         """Enable high-frequency MQTT reporting on all devices for fast cache warm-up.

--- a/monitor.py
+++ b/monitor.py
@@ -2365,14 +2365,14 @@ class PecronMonitor:
                     elapsed,
                     max_wait,
                 )
-                # Re-publish MQTT read requests for incomplete devices
-                if self.mqtt_client:
-                    for dk in incomplete:
-                        device = self._find_device(dk)
-                        if device:
-                            cid = self._channel_id(device)
-                            pkt = build_ttlv_read(self._next_packet_id())
-                            self.mqtt_client.publish(f"q/1/d/{cid}/bus", pkt, qos=1)
+                # Re-attempt via the normal status path (issue #84: this used to
+                # only re-publish MQTT read requests, so --local/offline mode --
+                # which has no mqtt_client -- never retried local TCP at all and
+                # just idled out the full 45s on a single initial attempt).
+                # _request_status() covers BLE/local TCP/MQTT-publish/REST for
+                # every device and is a no-op for any transport that isn't
+                # configured, so this is safe to call unconditionally here.
+                self._request_status()
                 last_request_time = elapsed
 
         if elapsed >= max_wait:

--- a/tests/unit/test_local_fix.py
+++ b/tests/unit/test_local_fix.py
@@ -66,6 +66,7 @@ def test_setup_local_transports_with_lan_ip_and_auth(
         fake_auth_key,
         device_key="AABBCCDDEEFF",
         controls={},
+        multi_packet_timeout=3.0,
     )
     assert "AABBCCDDEEFF" in monitor.local_transports
 
@@ -172,6 +173,7 @@ def test_cloud_auth_sets_up_local(
         fake_auth_key,
         device_key="AABBCCDDEEFF",
         controls={},
+        multi_packet_timeout=3.0,
     )
     assert "AABBCCDDEEFF" in monitor.local_transports
     assert monitor.offline_mode is False

--- a/tests/unit/test_model_behavior.py
+++ b/tests/unit/test_model_behavior.py
@@ -7,7 +7,7 @@ known no-op (E3600LFP) and still sent for models where it's effective.
 
 import base64
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # sys.path + paho mocking are handled globally by tests/conftest.py
 from constants import MODEL_BEHAVIOR
@@ -91,6 +91,33 @@ class TestModelBehavior(unittest.TestCase):
         m._enable_high_freq_reporting()
         # See test_enable_sends_for_e3800 -- verify=False on transient writes (#50).
         m.send_control.assert_called_once_with("dk0", "high_frequency_reporting", 3, verify=False)
+
+
+class TestLocalReadTimeout(unittest.TestCase):
+    """Regression for issue #84: E3600/E3800 local TCP multi-packet reads need
+    a longer inter-packet timeout than the 3.0s global default, or the read
+    cuts off before the packet carrying real voltage/temp telemetry arrives."""
+
+    def test_e3800_gets_extended_timeout(self):
+        m = make_monitor(["E3800LFP"])
+        self.assertEqual(m._local_read_timeout(m.devices[0]), 5.0)
+
+    def test_e3600_gets_extended_timeout(self):
+        m = make_monitor(["E3600LFP"])
+        self.assertEqual(m._local_read_timeout(m.devices[0]), 5.0)
+
+    def test_unlisted_model_uses_default(self):
+        m = make_monitor(["E1500LFP"])
+        self.assertEqual(m._local_read_timeout(m.devices[0]), 3.0)
+
+    def test_setup_passes_per_model_timeout_to_transport(self):
+        """_setup_local_transports must thread the per-model timeout through
+        to LocalTransport, not just compute it and drop it."""
+        m = make_monitor(["E3800LFP"])
+        with patch("monitor.HAS_LOCAL", True), patch("monitor.LocalTransport") as mock_transport:
+            m._setup_local_transports()
+            _, kwargs = mock_transport.call_args
+            self.assertEqual(kwargs.get("multi_packet_timeout"), 5.0)
 
 
 class TestE3600Capacity(unittest.TestCase):

--- a/tests/unit/test_status_once_local_retry.py
+++ b/tests/unit/test_status_once_local_retry.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Regression for issue #84: status_once()'s active collection loop used to
+re-request telemetry ONLY via MQTT cloud publish. In --local/offline mode
+there is no mqtt_client, so that retry was a no-op -- the 45s "Collecting
+data..." wait never re-attempted a local TCP read and just idled out on
+whatever the single initial _request_status() call happened to catch.
+
+Fix: the retry loop now calls _request_status() itself, which already
+handles local TCP (unconditionally) and MQTT-publish (only if connected),
+so offline mode gets real retries too.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from monitor import PecronMonitor
+
+
+def make_offline_monitor(make_config):
+    config = make_config(with_lan=True, with_auth=True)
+    monitor = PecronMonitor(config)
+    monitor.devices = [
+        {
+            "product_key": "p11u2b",
+            "device_key": "AABBCCDDEEFF",
+            "device_name": "E3800LFP",
+            "controls": {},
+        }
+    ]
+    monitor.mqtt_client = None  # offline/--local mode: no cloud connection
+    monitor.latest_data = {}  # never resolves to complete telemetry
+    return monitor
+
+
+def test_offline_status_once_retries_via_request_status(make_config):
+    monitor = make_offline_monitor(make_config)
+    monitor.authenticate = MagicMock()
+    monitor.offline_mode = True
+    monitor._request_status = MagicMock()
+
+    with patch("monitor.time.sleep"):
+        monitor.status_once(force_offline=True)
+
+    # max_wait=45s / check_interval=5s, re-request gated to every 10s ->
+    # multiple retries during the wait, not just the single initial call.
+    assert monitor._request_status.call_count > 1
+
+
+def test_offline_status_once_stops_once_telemetry_arrives(make_config):
+    monitor = make_offline_monitor(make_config)
+    monitor.authenticate = MagicMock()
+    monitor.offline_mode = True
+
+    calls = {"n": 0}
+
+    def fake_request_status():
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            monitor.latest_data["AABBCCDDEEFF"] = {
+                "host_packet_data_jdb": {"host_packet_voltage": 53.4, "host_packet_temp": 35}
+            }
+
+    monitor._request_status = MagicMock(side_effect=fake_request_status)
+
+    with patch("monitor.time.sleep"):
+        monitor.status_once(force_offline=True)
+
+    # Loop should exit as soon as telemetry lands, not run the full 45s.
+    assert calls["n"] <= 3

--- a/tests/unit/test_telemetry_field_detection.py
+++ b/tests/unit/test_telemetry_field_detection.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tests for PecronMonitor._has_telemetry_fields (issue #84).
+
+E3600/E3800 settings-only local TCP / cloud MQTT payloads include
+battery_percentage even though they carry no real telemetry (voltage,
+temperature, power). _has_telemetry_fields previously treated bare
+battery_percentage as sufficient evidence of "complete telemetry", which
+caused the --status collection loop to give up early ("All devices have
+telemetry data") while voltage/temperature were still unset, and caused
+settings-only local reads to be mislabeled as the primary data source.
+"""
+
+from monitor import PecronMonitor
+
+
+def make_monitor(make_config):
+    config = make_config()
+    return PecronMonitor(config)
+
+
+# The exact settings-only payload from issue #84's E3800LFP report --
+# battery_percentage plus a pile of settings fields, no voltage/temp/power.
+SETTINGS_ONLY_PAYLOAD = {
+    "ac_charging_power_ios": "1",
+    "ac_output_frequency_io": "1",
+    "ac_output_voltage_io": "2",
+    "ac_switch_hm": True,
+    "auto_light_flag_as": True,
+    "battery_percentage": "50",
+    "dc_switch_hm": True,
+    "device_touch_locking_as": False,
+    "eco_quite_mode_as": False,
+    "high_frequency_reporting": "0",
+    "machine_screen_light_as": "4",
+    "noastime_io": "0",
+    "ups_start_charge_value_as": "40",
+}
+
+
+def test_settings_only_payload_is_not_telemetry(make_config):
+    m = make_monitor(make_config)
+    assert m._has_telemetry_fields(SETTINGS_ONLY_PAYLOAD) is False
+
+
+def test_battery_percentage_with_flat_temp_is_telemetry(make_config):
+    """E300LFP/E3800-style flat payloads pair battery_percentage with a flat
+    temperature field -- that combination is real telemetry, not settings."""
+    m = make_monitor(make_config)
+    kv = dict(SETTINGS_ONLY_PAYLOAD, battery_temp=22)
+    assert m._has_telemetry_fields(kv) is True
+
+
+def test_host_packet_data_jdb_with_voltage_is_telemetry(make_config):
+    m = make_monitor(make_config)
+    kv = {
+        "host_packet_data_jdb": {
+            "host_packet_voltage": 53.2,
+            "host_packet_electric_percentage": 99,
+        }
+    }
+    assert m._has_telemetry_fields(kv) is True
+
+
+def test_empty_payload_is_not_telemetry(make_config):
+    m = make_monitor(make_config)
+    assert m._has_telemetry_fields({}) is False


### PR DESCRIPTION
## Summary
- Fixes #84 — E3800LFP `--local` never reports data (stuck on settings-only payloads / `Voltage: 0.0V`, `Status: Unknown (-1)`).
- Restore a per-model inter-packet timeout for local TCP multi-packet reads (`LOCAL_READ_TIMEOUT_OVERRIDES`: 5.0s for E3600/E3800, 3.0s default elsewhere). The global timeout was cut from 5.0s to 3.0s in #6 to fix polling drift on single-packet models, but E3600/E3800 split telemetry across 3-4 packets with up to ~3-4s gaps (per #15) — 3.0s silently cuts the read off before the packet carrying real voltage/temp arrives.
- Fix `_has_telemetry_fields()` treating bare `battery_percentage` as "complete telemetry" — it's present in E3600/E3800 settings-only payloads too, so it can't on its own distinguish real telemetry from settings. This is why `--status` printed `"All devices have telemetry data (5s)"` and then showed `0.0V`/`Unknown` — it gave up its 45s collection loop on the very first poll. Now requires `battery_percentage` alongside a flat temperature field (`battery_temp`/`charging_plate_temp`/`inverter_temp`) as corroborating evidence.

## Test plan
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `python -m py_compile pecron_monitor.py local_transport.py`
- [x] `pytest -v` — 371 passed, 6 skipped (pre-existing, no hardware captures), 0 failed
- [x] Added regression coverage: `tests/unit/test_telemetry_field_detection.py` (settings-only payload from #84's report is correctly rejected) + `TestLocalReadTimeout` in `tests/unit/test_model_behavior.py` (per-model timeout wiring)
- [ ] Needs confirmation from @mat1990dj on real E3800LFP hardware — I don't have a unit to test against directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)