### PR TITLE
Add HA energy sensors and continuous local retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to pecron-monitor are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
 
+## [Unreleased]
+
+### Added
+- Optional turnkey Home Assistant kWh sensors for AC input, AC output, and DC output (`homeassistant.energy_sensors: true`). Counters survive restarts, use Energy Dashboard-compatible MQTT discovery metadata, and avoid integrating unavailable or excessively stale readings (#79).
+
+### Fixed
+- Continuous local monitoring now retries incomplete E3600/E3800 multi-packet reads within the current poll cycle, targets only devices still missing telemetry, and advances to the next future cycle boundary when retries overrun an interval (#88).
+
+
 ## [0.7.18] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ homeassistant:
   mqtt_password: "pass"
   discovery_prefix: "homeassistant"
   clear_discovery_on_startup: true
+  energy_sensors: true
+  energy_max_gap_seconds: 1800
+  # energy_state_path: "~/.pecron-monitor-energy.json"
 ```
 
 Run with `--homeassistant` or just start normally (auto-detects if enabled). Your Pecron appears in HA with battery sensors, power sensors, remaining time, and AC/DC/UPS switches.
@@ -275,49 +278,42 @@ publish-only behavior.
 
 ### Energy Dashboard
 
-The Pecron's input/output channels are published as **power** sensors (Watts):
-AC Input Power, AC Output Power, DC Input Power, DC Output Power. Home
-Assistant's **Energy Dashboard only accepts energy sensors (kWh)** — it cannot
-add a Watt sensor directly, which is why these don't show up in the dashboard's
-device picker even though the values look correct.
+Set `homeassistant.energy_sensors: true` to publish turnkey cumulative energy
+sensors for **AC Input**, **AC Output**, and **DC Output**. They use
+`device_class: energy`, `state_class: total_increasing`, and `kWh`, so Home
+Assistant can add them directly under Settings → Dashboards → **Energy** without
+a Riemann-sum helper.
 
-The device firmware does not report cumulative kWh counters for these channels
-(only PV models expose a `Total PV Energy` sensor), so the fix is to let Home
-Assistant integrate power over time with its built-in **Riemann sum integral**
-helper. Each power sensor declares `state_class: measurement`, so HA records
-long-term statistics for it and can integrate it cleanly.
+The counters integrate observed power readings and persist to
+`~/.pecron-monitor-energy.json` by default. Override that path with
+`homeassistant.energy_state_path` or `PECRON_ENERGY_STATE_PATH`. The bridge does
+not integrate time while it is stopped, unavailable/non-numeric readings, or
+gaps longer than `energy_max_gap_seconds` (30 minutes by default). Raise the gap
+limit if valid device telemetry normally arrives less often.
 
-**UI (easiest):** Settings → Devices & Services → **Helpers** → Create Helper →
-**Integration - Riemann sum integral**. Pick a Pecron power sensor as the source,
-set **Metric prefix = `k` (kilo)** and **Time unit = `h` (hours)**. The result is
-a kWh sensor you can add under Settings → Dashboards → **Energy**.
+These derived totals are approximate, not revenue-grade: their resolution and
+accuracy are bounded by the telemetry cadence. The bridge intentionally does not
+derive DC input/solar energy. Use the device's native `Total PV Energy` counter
+where available, or the Home Assistant helper below for models without one.
 
-**YAML** equivalent (use your own entity IDs):
+If built-in energy sensors are disabled, or you need a derived counter for
+another power channel, Home Assistant's **Integration - Riemann sum integral**
+helper remains available. Pick the Pecron power sensor, set **Metric prefix =
+`k`** and **Time unit = `h`**. The YAML equivalent is:
 
 ```yaml
 sensor:
   - platform: integration
-    source: sensor.pecron_e1500lfp_ac_input_power   # grid charging in
-    name: Pecron AC Input Energy
-    unit_prefix: k       # -> kWh
-    unit_time: h
-    method: left
-    max_sub_interval: "00:05:00"   # advance even when power is steady
-  - platform: integration
-    source: sensor.pecron_e1500lfp_ac_output_power  # AC load out
+    source: sensor.pecron_e1500lfp_ac_output_power
     name: Pecron AC Output Energy
     unit_prefix: k
     unit_time: h
     method: left
     max_sub_interval: "00:05:00"
-  # ...repeat for DC Input Power (solar) and DC Output Power
 ```
 
-Then in the Energy Dashboard add the AC/DC **Output** energy sensors under
-"Individual devices", and the **Input** energy sensors (e.g. solar) under "Solar
-panels" or "Grid consumption" as appropriate. Note that resolution is bounded by
-`poll_interval` (the bridge only publishes new values that often), so the energy
-totals are approximate, not revenue-grade.
+Then add the resulting output energy sensor under "Individual devices", or an
+input energy sensor under "Solar panels" / "Grid consumption" as appropriate.
 
 ## Running as a Service
 

--- a/docs/known-pecron-api-quirks.md
+++ b/docs/known-pecron-api-quirks.md
@@ -62,22 +62,31 @@ The "3600" in E3600LFP is the inverter wattage, not the battery capacity. The ac
 **First documented here:** [pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
 **Affects:** Cloud MQTT on E3600LFP and E3800LFP
 
-On these two models the cloud sends telemetry in 2-3 alternating packet shapes spaced roughly 10-15 seconds apart. A single MQTT message will contain only battery+status, or only voltage+power, or only settings, never everything in one payload. Clients that request data once and wait a fixed interval will see a partial picture.
+These models split telemetry across alternating packet shapes: battery/status,
+voltage/power, and settings can arrive separately, so one message is not a
+complete snapshot. The cadence differs by firmware:
 
-pecron-monitor works around this by:
+- E3800LFP responds to `high_frequency_reporting=3`; packet shapes then arrive
+  roughly 10-15 seconds apart.
+- E3600LFP ignores that property. Hardware testing found each packet type stayed
+  on an approximately 20-minute cadence, with packet types offset from each
+  other. The official app's open status screen can trigger faster reports, but
+  no app-free cloud command is known ([issue #30](https://github.com/attractify-logan/pecron-monitor/issues/30)).
 
-1. Enabling `high_frequency_reporting=3` at startup for a short warm-up window (see `high_freq_warmup_seconds` in `config.yaml`, default 60s) so the full packet sequence arrives quickly.
-2. Disabling it again after warm-up (see the next quirk for why).
-3. Merging partial packets with a last-known-good cache (`_state_cache` in `ha_bridge.py`) so Home Assistant entities don't flap to `unknown` between packets.
+pecron-monitor merges partial packets into its last-known-good state. During
+startup it also enables high-frequency reporting briefly on models where the
+setting is effective, then disables it again. E3600/E3600LFP are explicitly
+excluded from those writes because they do not change the device's cadence.
 
 ## Persistent `high_frequency_reporting=3` burns cloud quota (error 4026)
 
 **First documented here:** [pecron-monitor v0.7.0 changelog](../CHANGELOG.md)
-**Affects:** Cloud MQTT, any model
+**Affects:** Cloud MQTT on models where high-frequency reporting is effective
 
-Leaving `high_frequency_reporting` enabled indefinitely eventually returns error code 4026 (`"Insufficient resources in manufacturer's account"`) and stops all cloud telemetry until it's disabled. The monitor enables it only long enough to fill the initial telemetry cache, then flips it back to 0.
-
-If you set `high_freq_warmup_seconds: 0`, be aware that slow devices (E3600/E3800 per above) may never produce a complete status log, and setting it to a very large number risks tripping 4026.
+Leaving high-frequency reporting enabled indefinitely can return error code 4026
+(`"Insufficient resources in manufacturer's account"`) and stop cloud telemetry.
+The monitor uses it only for the initial cache warm-up, then restores the normal
+reporting mode. Setting `high_freq_warmup_seconds: 0` disables that warm-up.
 
 ## `code 4007 "device is not bound"` is frequently a false positive
 
@@ -88,14 +97,25 @@ When sending a control command or verifying a device, Pecron's cloud sometimes r
 
 Treat 4007 as actionable only if it persists *and* the device also never produces telemetry. The monitor logs it as a warning once per session to avoid alert fatigue.
 
-## E3600LFP local TCP read returns only settings fields (no telemetry)
+## E3600LFP local TCP telemetry is inconsistent and not yet verified in normal operation
 
 **First documented here:** [pecron-monitor issue #14](https://github.com/attractify-logan/pecron-monitor/issues/14)
+**Tracked in:** [pecron-monitor issue #30](https://github.com/attractify-logan/pecron-monitor/issues/30)
 **Affects:** Local TCP (port 6607) on E3600LFP
 
-A standard TTLV read command to the E3600LFP over local TCP returns exactly 8 fields: `ac_output_voltage_io`, `ac_output_frequency_io`, `noastime_io`, `ac_switch_hm`, `auto_light_flag_as`, `machine_screen_light_as`, `device_manual`, `high_frequency_reporting`. Battery, voltage, power, and temperature are missing from this response.
+Early captures returned only eight settings fields and no battery, voltage,
+power, or temperature. A later offline-only low-battery/shutdown capture did
+return battery percentage, voltage, and temperature over local TCP, but its
+power and remaining-time values were zero/default. That proves richer local data
+is possible in at least one device state, not that it is reliable during normal
+operation.
 
-Unlike the E1500LFP (which returns the full property set in a single local read), the E3600LFP appears to restrict local-TCP responses to control-type properties. Workarounds attempted in `fix/e3600-data`: parsing the `extData` field on cloud MQTT bus messages, falling back to the REST `getDeviceBusinessAttributes` endpoint, and registering new TSL IDs for E3600-specific property shifts (e.g. `ac_switch_hm` at id=56 instead of 40). Investigation ongoing.
+Current releases use a longer inter-packet timeout and active retries for the
+E3600/E3800 packet family. This behavior is hardware-confirmed on E3800LFP; an
+E3600LFP `--local --status -v` / `--raw --local -v` capture with every official
+app instance closed is still needed to verify normal-operation cadence and field
+completeness. Until then, local mode is a testable lead rather than a documented
+workaround for the E3600 cloud limit.
 
 ## Pecron device MAC address matches the `device_key` byte-for-byte
 

--- a/energy_state.py
+++ b/energy_state.py
@@ -1,0 +1,160 @@
+"""Persisted power-to-energy integration for Home Assistant sensors."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable, Mapping, Optional
+
+log = logging.getLogger("pecron")
+
+ENERGY_CHANNELS = ("ac_input", "ac_output", "dc_output")
+DEFAULT_MAX_GAP_SECONDS = 1800.0
+
+
+def state_path(configured_path: Optional[str] = None) -> Path:
+    """Resolve the energy-counter state path, with an environment override for tests."""
+    override = os.environ.get("PECRON_ENERGY_STATE_PATH")
+    if override:
+        return Path(override).expanduser()
+    if configured_path:
+        return Path(configured_path).expanduser()
+    return Path.home() / ".pecron-monitor-energy.json"
+
+
+class EnergyIntegrator:
+    """Integrate observed channel power into per-device persisted kWh counters."""
+
+    def __init__(
+        self,
+        *,
+        configured_path: Optional[str] = None,
+        max_gap_seconds: float = DEFAULT_MAX_GAP_SECONDS,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self.path = state_path(configured_path)
+        self.max_gap_seconds = float(max_gap_seconds)
+        if not math.isfinite(self.max_gap_seconds) or self.max_gap_seconds <= 0:
+            raise ValueError("energy_max_gap_seconds must be a positive finite number")
+        self.clock = clock or time.monotonic
+        self._totals = self._load()
+        self._samples: dict[str, dict[str, tuple[float, float]]] = {}
+
+    def update(self, device_key: str, readings: Mapping[str, object]) -> dict[str, float]:
+        """Observe power readings and return counters for channels valid in this observation.
+
+        Integration uses the trapezoidal rule between two valid observations. Missing channels
+        leave their prior observation untouched because Pecron telemetry arrives in partial packet
+        shapes. An explicitly unavailable value breaks that channel's continuity.
+        """
+        if not readings:
+            return {}
+
+        observed_at = float(self.clock())
+        totals = self._totals.setdefault(device_key, {})
+        samples = self._samples.setdefault(device_key, {})
+        available: dict[str, float] = {}
+        changed = False
+
+        for channel in ENERGY_CHANNELS:
+            if channel not in readings:
+                continue
+
+            power = self._valid_power(readings[channel])
+            if power is None:
+                samples.pop(channel, None)
+                continue
+
+            total = totals.setdefault(channel, 0.0)
+            previous = samples.get(channel)
+            samples[channel] = (observed_at, power)
+            available[channel] = total
+            if previous is None:
+                continue
+
+            previous_at, previous_power = previous
+            elapsed = observed_at - previous_at
+            if elapsed <= 0 or elapsed > self.max_gap_seconds:
+                continue
+
+            increment = ((previous_power + power) / 2.0) * elapsed / 3_600_000.0
+            if increment > 0:
+                totals[channel] = total + increment
+                available[channel] = totals[channel]
+                changed = True
+
+        if changed:
+            self._save()
+        return available
+
+    @staticmethod
+    def _valid_power(raw: object) -> Optional[float]:
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(value) or value < 0:
+            return None
+        return value
+
+    def _load(self) -> dict[str, dict[str, float]]:
+        if not self.path.exists():
+            return {}
+        try:
+            with self.path.open("r") as state_file:
+                payload = json.load(state_file)
+        except (OSError, json.JSONDecodeError) as error:
+            log.warning(
+                "Could not read %s (%s); treating energy counters as empty.", self.path, error
+            )
+            return {}
+
+        raw_devices = payload.get("devices", {}) if isinstance(payload, dict) else {}
+        if not isinstance(raw_devices, dict):
+            return {}
+
+        devices: dict[str, dict[str, float]] = {}
+        for device_key, raw_channels in raw_devices.items():
+            if not isinstance(device_key, str) or not isinstance(raw_channels, dict):
+                continue
+            channels: dict[str, float] = {}
+            for channel in ENERGY_CHANNELS:
+                value = self._valid_energy(raw_channels.get(channel))
+                if value is not None:
+                    channels[channel] = value
+            if channels:
+                devices[device_key] = channels
+        return devices
+
+    @staticmethod
+    def _valid_energy(raw: object) -> Optional[float]:
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(value) or value < 0:
+            return None
+        return value
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"devices": self._totals}
+        fd, temporary_name = tempfile.mkstemp(prefix=".pecron-energy-", dir=str(self.path.parent))
+        temporary_path = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "w") as state_file:
+                json.dump(payload, state_file, indent=2, sort_keys=True)
+                state_file.flush()
+                os.fsync(state_file.fileno())
+            temporary_path.replace(self.path)
+        except Exception:
+            try:
+                temporary_path.unlink()
+            except OSError:
+                pass
+            raise

--- a/ha_bridge.py
+++ b/ha_bridge.py
@@ -14,6 +14,7 @@ except ImportError:
     mqtt = None
 
 from helpers import _truthy, _get_kv_single, _fmt_dhm
+from energy_state import DEFAULT_MAX_GAP_SECONDS, EnergyIntegrator
 from constants import (
     SENSOR_FIELDS,
     DEVICE_STATUS_LABELS,
@@ -142,6 +143,15 @@ class HomeAssistantBridge:
         # service restart instead of requiring a manual MQTT integration reload.
         self.clear_discovery_on_startup = ha_config.get("clear_discovery_on_startup", True)
         self._clear_current_discovery = False
+        # Derived kWh counters are strictly opt-in. Their persistence and sampling
+        # state are not touched when disabled, preserving the legacy bridge path.
+        self.energy_sensors = bool(_truthy(ha_config.get("energy_sensors", False)))
+        self._energy = None
+        if self.energy_sensors:
+            self._energy = EnergyIntegrator(
+                configured_path=ha_config.get("energy_state_path"),
+                max_gap_seconds=ha_config.get("energy_max_gap_seconds", DEFAULT_MAX_GAP_SECONDS),
+            )
 
         # Deferred-discovery bookkeeping. Per-port DC-input entities
         # (dc5521, gx16mf1, gx16mf2) are only published the first time the
@@ -762,6 +772,29 @@ class HomeAssistantBridge:
                     },
                 )
 
+                if self.energy_sensors:
+                    for channel, label in (
+                        ("ac_input", "AC Input Energy"),
+                        ("ac_output", "AC Output Energy"),
+                        ("dc_output", "DC Output Energy"),
+                    ):
+                        key = f"{channel}_energy"
+                        self._pub_config(
+                            "sensor",
+                            dk,
+                            key,
+                            {
+                                "name": label,
+                                "device_class": "energy",
+                                "state_class": "total_increasing",
+                                "unit_of_measurement": "kWh",
+                                "state_topic": f"pecron/{dk}/state",
+                                "value_template": f"{{{{ value_json.{key} }}}}",
+                                "device": dev_info,
+                                "unique_id": f"pecron_{dk}_{key}",
+                            },
+                        )
+
             # Per-port DC input sensors (DC5521 barrel, GX16-MF1/2 solar).
             # NOT published here. Deferred to publish_state so we only register
             # entities for ports that actually exist on the device. Models
@@ -1247,6 +1280,9 @@ class HomeAssistantBridge:
                 "dc_input",
                 "ac_output",
                 "dc_output",
+                "ac_input_energy",
+                "ac_output_energy",
+                "dc_output_energy",
                 "ac_output_voltage",
                 "ac_output_hz",
                 "ac_output_pf",
@@ -1315,6 +1351,21 @@ class HomeAssistantBridge:
                 if val is not None:
                     return True, val
             return False, None
+
+        def _get_first_observed(paths):
+            """Return a source path even when its observed value is unavailable."""
+            unavailable_observed = False
+            for path in paths:
+                value = kv
+                for part in path:
+                    if not isinstance(value, dict) or part not in value:
+                        break
+                    value = value[part]
+                else:
+                    if value is not None:
+                        return True, value
+                    unavailable_observed = True
+            return unavailable_observed, None
 
         # Identify payload shape (host packet vs overall packet)
         host_dict = kv.get("host_packet_data_jdb")
@@ -1756,6 +1807,15 @@ class HomeAssistantBridge:
         cache.setdefault("soc_percent", None)
         cache.setdefault("remain_hm", _fmt_dhm(cache.get("remain_minutes")))
         cache.setdefault("remain_charging_hm", _fmt_dhm(cache.get("remain_charging_minutes")))
+
+        if self._energy is not None:
+            readings = {}
+            for channel in ("ac_input", "ac_output", "dc_output"):
+                observed, value = _get_first_observed(SENSOR_FIELDS[f"{channel}_power"])
+                if observed:
+                    readings[channel] = value
+            for channel, total in self._energy.update(device_key, readings).items():
+                cache[f"{channel}_energy"] = round(total, 9)
 
         self.client.publish(f"pecron/{device_key}/state", json.dumps(cache), qos=1, retain=True)
 

--- a/monitor.py
+++ b/monitor.py
@@ -2154,11 +2154,7 @@ class PecronMonitor:
         if not eligible:
             return 0.0
 
-        incomplete = {
-            device_key
-            for device_key in eligible
-            if not self._has_telemetry_fields(self.latest_data.get(device_key, {}))
-        }
+        incomplete = eligible.difference(self._local_data_keys)
         deadline = cycle_started + min(45.0, max(0.0, float(poll_interval)))
 
         while incomplete and self._running:
@@ -2168,11 +2164,7 @@ class PecronMonitor:
 
             time.sleep(min(10.0, remaining))
             self._request_status(device_keys=incomplete)
-            incomplete = {
-                device_key
-                for device_key in incomplete
-                if not self._has_telemetry_fields(self.latest_data.get(device_key, {}))
-            }
+            incomplete.difference_update(self._local_data_keys)
 
         return time.monotonic() - cycle_started
 

--- a/monitor.py
+++ b/monitor.py
@@ -1602,11 +1602,17 @@ class PecronMonitor:
 
     # --- Status request ---
 
-    def _request_status(self):
-        # Clear local data keys at start of polling cycle to allow fresh tracking
-        self._local_data_keys.clear()
+    def _request_status(self, device_keys: Optional[set[str]] = None):
+        # Clear local data tracking only for devices included in this request.
+        # Targeted within-cycle retries must not discard other devices' source state.
+        if device_keys is None:
+            self._local_data_keys.clear()
+        else:
+            self._local_data_keys.difference_update(device_keys)
 
         for device in self.devices:
+            if device_keys is not None and device["device_key"] not in device_keys:
+                continue
             dk = device["device_key"]
 
             # Priority: BLE → TCP/WiFi → Cloud MQTT → REST API
@@ -2125,6 +2131,51 @@ class PecronMonitor:
 
     # --- Main loop ---
 
+    def _continuous_local_retry_device_keys(self) -> set[str]:
+        """Return local multi-packet devices eligible for within-cycle retries."""
+        return {
+            device["device_key"]
+            for device in self.devices
+            if device["device_key"] in self.local_transports
+            and (device.get("device_name") or device.get("product_name") or "")
+            in LOCAL_READ_TIMEOUT_OVERRIDES
+        }
+
+    def _request_status_with_local_retries(self, poll_interval: float) -> float:
+        """Request one cycle, retrying incomplete local multi-packet devices.
+
+        Returns the elapsed portion of the poll cycle so ``run`` can wait only
+        for the remaining interval rather than stacking a fresh interval after
+        retries.
+        """
+        eligible = self._continuous_local_retry_device_keys()
+        cycle_started = time.monotonic()
+        self._request_status()
+        if not eligible:
+            return 0.0
+
+        incomplete = {
+            device_key
+            for device_key in eligible
+            if not self._has_telemetry_fields(self.latest_data.get(device_key, {}))
+        }
+        deadline = cycle_started + min(45.0, max(0.0, float(poll_interval)))
+
+        while incomplete and self._running:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+
+            time.sleep(min(10.0, remaining))
+            self._request_status(device_keys=incomplete)
+            incomplete = {
+                device_key
+                for device_key in incomplete
+                if not self._has_telemetry_fields(self.latest_data.get(device_key, {}))
+            }
+
+        return time.monotonic() - cycle_started
+
     def run(self, enable_ha=False, force_offline=False):
         self._running = True
 
@@ -2163,11 +2214,18 @@ class PecronMonitor:
             warmup_start = time.time()
 
         time.sleep(3)
-        self._request_status()
+        cycle_elapsed = self._request_status_with_local_retries(poll_interval)
 
         try:
             while self._running:
-                time.sleep(poll_interval)
+                if poll_interval > 0:
+                    cycle_remainder = cycle_elapsed % poll_interval
+                    cycle_delay = (
+                        poll_interval if cycle_remainder == 0 else poll_interval - cycle_remainder
+                    )
+                else:
+                    cycle_delay = 0.0
+                time.sleep(cycle_delay)
                 # Check if warm-up period has ended — disable high-freq to save cloud quota
                 if self.mqtt_client and high_freq_warmup_seconds > 0:
                     elapsed = time.time() - warmup_start
@@ -2201,7 +2259,7 @@ class PecronMonitor:
                 if self.ha_bridge:
                     self.ha_bridge.try_reconnect()
 
-                self._request_status()
+                cycle_elapsed = self._request_status_with_local_retries(poll_interval)
 
         except KeyboardInterrupt:
             log.info("Shutting down...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pecron-monitor = "pecron_monitor:main"
 py-modules = [
     "cloud_api",
     "constants",
+    "energy_state",
     "ha_bridge",
     "helpers",
     "lan_scan",

--- a/tests/unit/test_ha_energy_sensors.py
+++ b/tests/unit/test_ha_energy_sensors.py
@@ -1,0 +1,195 @@
+"""Focused tests for opt-in Home Assistant energy sensors (issue #79)."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from energy_state import EnergyIntegrator
+from ha_bridge import HomeAssistantBridge
+
+
+class FakeClock:
+    def __init__(self, initial=0.0):
+        self.now = float(initial)
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def _device(device_key="DEV1", name="E1500LFP"):
+    return {"device_key": device_key, "device_name": name, "controls": {}}
+
+
+def _bridge(tmp_path, *, enabled, max_gap=7200, devices=None):
+    bridge = HomeAssistantBridge(
+        {
+            "discovery_prefix": "homeassistant",
+            "clear_discovery_on_startup": False,
+            "energy_sensors": enabled,
+            "energy_state_path": str(tmp_path / "energy.json"),
+            "energy_max_gap_seconds": max_gap,
+        },
+        devices=devices or [_device()],
+    )
+    bridge.client = MagicMock()
+    bridge._connected = True
+    return bridge
+
+
+def _power_payload(ac_input, ac_output, dc_output):
+    return {
+        "ac_data_input_hm": {"ac_input_power": ac_input},
+        "ac_data_output_hm": {"ac_output_power": ac_output},
+        "dc_data_output_hm": {"dc_output_power": dc_output},
+    }
+
+
+def _published_state(bridge):
+    calls = [
+        call.args
+        for call in bridge.client.publish.call_args_list
+        if call.args[0].endswith("/state")
+    ]
+    return json.loads(calls[-1][1])
+
+
+def test_energy_discovery_is_opt_in_and_energy_dashboard_compatible(tmp_path):
+    expected = {"ac_input_energy", "ac_output_energy", "dc_output_energy"}
+    disabled = _bridge(tmp_path, enabled=False)
+    disabled._publish_discovery()
+    disabled_payloads = [
+        call.args[1]
+        for call in disabled.client.publish.call_args_list
+        if call.args[0].split("/")[-2] in expected and call.args[1]
+    ]
+    assert disabled_payloads == []
+
+    enabled = _bridge(tmp_path, enabled=True)
+    enabled._publish_discovery()
+    payloads = {}
+    for call in enabled.client.publish.call_args_list:
+        topic, raw_payload = call.args[:2]
+        key = topic.split("/")[-2]
+        if key in expected and raw_payload:
+            payloads[key] = json.loads(raw_payload)
+
+    assert set(payloads) == expected
+    for key, payload in payloads.items():
+        assert payload["device_class"] == "energy"
+        assert payload["state_class"] == "total_increasing"
+        assert payload["unit_of_measurement"] == "kWh"
+        assert payload["value_template"] == f"{{{{ value_json.{key} }}}}"
+    assert "total_energy" not in payloads
+
+
+def test_energy_discovery_excludes_non_power_station_devices(tmp_path):
+    bridge = _bridge(tmp_path, enabled=True, devices=[_device(name="WB12200")])
+    bridge._publish_discovery()
+    assert not any(
+        call.args[0].endswith("_energy/config") and call.args[1]
+        for call in bridge.client.publish.call_args_list
+    )
+
+
+def test_bridge_accumulates_each_channel_with_controllable_clock(tmp_path):
+    bridge = _bridge(tmp_path, enabled=True)
+    clock = FakeClock()
+    bridge._energy.clock = clock
+
+    bridge.publish_state("DEV1", _power_payload(1000, 500, 100))
+    first = _published_state(bridge)
+    assert first["ac_input_energy"] == 0.0
+    assert first["ac_output_energy"] == 0.0
+    assert first["dc_output_energy"] == 0.0
+
+    clock.advance(3600)
+    bridge.publish_state("DEV1", _power_payload(1000, 1000, 300))
+    state = _published_state(bridge)
+    assert state["ac_input_energy"] == pytest.approx(1.0)
+    assert state["ac_output_energy"] == pytest.approx(0.75)
+    assert state["dc_output_energy"] == pytest.approx(0.2)
+
+
+def test_persisted_counters_reload_across_bridge_restart(tmp_path):
+    clock = FakeClock()
+    first_bridge = _bridge(tmp_path, enabled=True)
+    first_bridge._energy.clock = clock
+    first_bridge.publish_state("DEV1", _power_payload(600, 300, 120))
+    clock.advance(60)
+    first_bridge.publish_state("DEV1", _power_payload(600, 300, 120))
+    before_restart = _published_state(first_bridge)
+
+    restarted_bridge = _bridge(tmp_path, enabled=True)
+    restarted_bridge._energy.clock = FakeClock(10_000)
+    restarted_bridge.publish_state("DEV1", _power_payload(600, 300, 120))
+    after_restart = _published_state(restarted_bridge)
+
+    assert after_restart["ac_input_energy"] == before_restart["ac_input_energy"]
+    assert after_restart["ac_output_energy"] == before_restart["ac_output_energy"]
+    assert after_restart["dc_output_energy"] == before_restart["dc_output_energy"]
+    assert not list(tmp_path.glob(".pecron-energy-*"))
+
+
+def test_unavailable_values_break_continuity_without_adding_energy(tmp_path):
+    clock = FakeClock()
+    integrator = EnergyIntegrator(
+        configured_path=str(tmp_path / "energy.json"), max_gap_seconds=300, clock=clock
+    )
+    integrator.update("DEV", {"ac_input": 1000, "ac_output": 500, "dc_output": 100})
+
+    clock.advance(60)
+    assert integrator.update("DEV", {"ac_input": None, "ac_output": "not-a-number"}) == {}
+    clock.advance(60)
+    resumed = integrator.update("DEV", {"ac_input": 1000, "ac_output": 500, "dc_output": 100})
+
+    assert resumed["ac_input"] == 0.0
+    assert resumed["ac_output"] == 0.0
+    assert resumed["dc_output"] == pytest.approx(100 * 120 / 3_600_000)
+
+
+def test_default_gap_allows_e3600_twenty_minute_telemetry_cadence(tmp_path):
+    clock = FakeClock()
+    integrator = EnergyIntegrator(configured_path=str(tmp_path / "energy.json"), clock=clock)
+    integrator.update("E3600", {"ac_input": 1000})
+
+    clock.advance(20 * 60)
+    total = integrator.update("E3600", {"ac_input": 1000})["ac_input"]
+
+    assert total == pytest.approx(1 / 3)
+
+
+def test_non_positive_time_and_excessive_gap_do_not_add_energy(tmp_path):
+    clock = FakeClock(100)
+    integrator = EnergyIntegrator(
+        configured_path=str(tmp_path / "energy.json"), max_gap_seconds=60, clock=clock
+    )
+    assert integrator.update("DEV", {"ac_input": 1000}) == {"ac_input": 0.0}
+    assert integrator.update("DEV", {"ac_input": 2000}) == {"ac_input": 0.0}
+
+    clock.advance(-10)
+    assert integrator.update("DEV", {"ac_input": 2000}) == {"ac_input": 0.0}
+    clock.advance(71)
+    assert integrator.update("DEV", {"ac_input": 2000}) == {"ac_input": 0.0}
+
+
+def test_devices_accumulate_in_isolation(tmp_path):
+    clock = FakeClock()
+    integrator = EnergyIntegrator(
+        configured_path=str(tmp_path / "energy.json"), max_gap_seconds=300, clock=clock
+    )
+    integrator.update("A", {"ac_input": 1000})
+    integrator.update("B", {"ac_input": 2000})
+    clock.advance(180)
+
+    total_a = integrator.update("A", {"ac_input": 1000})["ac_input"]
+    total_b = integrator.update("B", {"ac_input": 2000})["ac_input"]
+
+    assert total_a == pytest.approx(0.05)
+    assert total_b == pytest.approx(0.1)
+    persisted = json.loads((tmp_path / "energy.json").read_text())["devices"]
+    assert persisted["A"]["ac_input"] == pytest.approx(0.05)
+    assert persisted["B"]["ac_input"] == pytest.approx(0.1)

--- a/tests/unit/test_run_local_retry.py
+++ b/tests/unit/test_run_local_retry.py
@@ -54,6 +54,9 @@ def make_monitor(make_config, model="E3800LFP", *, local=True, poll_interval=25)
 
 def test_incomplete_eligible_local_device_retries_within_cycle(make_config):
     monitor = make_monitor(make_config)
+    # A complete value in the persistent merged cache came from an older cycle
+    # and must not suppress retries for this cycle's settings-only local read.
+    monitor.latest_data["AABBCCDDEEFF"] = dict(TELEMETRY)
     clock = FakeClock()
     monitor._request_status = MagicMock()
 
@@ -78,7 +81,7 @@ def test_complete_eligible_local_data_stops_without_retry(make_config):
     clock = FakeClock()
 
     def complete_first_request(device_keys=None):
-        monitor.latest_data["AABBCCDDEEFF"] = dict(TELEMETRY)
+        monitor._local_data_keys.add("AABBCCDDEEFF")
 
     monitor._request_status = MagicMock(side_effect=complete_first_request)
 

--- a/tests/unit/test_run_local_retry.py
+++ b/tests/unit/test_run_local_retry.py
@@ -1,0 +1,141 @@
+"""Focused coverage for continuous local multi-packet retries (issue #88)."""
+
+from unittest.mock import MagicMock, call, patch
+
+from monitor import PecronMonitor
+
+
+SETTINGS_ONLY = {"battery_percentage": 75, "ac_switch_hm": True}
+TELEMETRY = {
+    "host_packet_data_jdb": {
+        "host_packet_voltage": 52.8,
+        "host_packet_temp": 24,
+    }
+}
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps = []
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        assert seconds >= 0
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def make_monitor(make_config, model="E3800LFP", *, local=True, poll_interval=25):
+    config = make_config(with_lan=local, with_auth=local)
+    config["poll_interval"] = poll_interval
+    config["devices"][0]["name"] = model
+    monitor = PecronMonitor(config)
+    monitor.devices = [
+        {
+            "product_key": "p11u2b",
+            "device_key": "AABBCCDDEEFF",
+            "device_name": model,
+            "product_name": model,
+            "controls": {},
+        }
+    ]
+    if local:
+        monitor.local_transports = {"AABBCCDDEEFF": object()}
+    monitor.latest_data = {"AABBCCDDEEFF": dict(SETTINGS_ONLY)}
+    monitor._running = True
+    return monitor
+
+
+def test_incomplete_eligible_local_device_retries_within_cycle(make_config):
+    monitor = make_monitor(make_config)
+    clock = FakeClock()
+    monitor._request_status = MagicMock()
+
+    with (
+        patch("monitor.time.monotonic", side_effect=clock.monotonic),
+        patch("monitor.time.sleep", side_effect=clock.sleep),
+    ):
+        elapsed = monitor._request_status_with_local_retries(25)
+
+    assert monitor._request_status.call_args_list == [
+        call(),
+        call(device_keys={"AABBCCDDEEFF"}),
+        call(device_keys={"AABBCCDDEEFF"}),
+        call(device_keys={"AABBCCDDEEFF"}),
+    ]
+    assert clock.sleeps == [10.0, 10.0, 5.0]
+    assert elapsed == 25.0
+
+
+def test_complete_eligible_local_data_stops_without_retry(make_config):
+    monitor = make_monitor(make_config)
+    clock = FakeClock()
+
+    def complete_first_request(device_keys=None):
+        monitor.latest_data["AABBCCDDEEFF"] = dict(TELEMETRY)
+
+    monitor._request_status = MagicMock(side_effect=complete_first_request)
+
+    with (
+        patch("monitor.time.monotonic", side_effect=clock.monotonic),
+        patch("monitor.time.sleep", side_effect=clock.sleep),
+    ):
+        elapsed = monitor._request_status_with_local_retries(25)
+
+    monitor._request_status.assert_called_once_with()
+    assert clock.sleeps == []
+    assert elapsed == 0.0
+
+
+def test_non_multi_packet_model_remains_single_attempt(make_config):
+    monitor = make_monitor(make_config, model="E1500LFP")
+    clock = FakeClock()
+    monitor._request_status = MagicMock()
+
+    with (
+        patch("monitor.time.monotonic", side_effect=clock.monotonic),
+        patch("monitor.time.sleep", side_effect=clock.sleep),
+    ):
+        elapsed = monitor._request_status_with_local_retries(25)
+
+    monitor._request_status.assert_called_once_with()
+    assert clock.sleeps == []
+    assert elapsed == 0.0
+
+
+def test_elapsed_retry_time_never_creates_negative_or_stacked_cycle_delay(make_config):
+    monitor = make_monitor(make_config, poll_interval=10)
+    clock = FakeClock()
+    request_count = 0
+
+    def request_status(device_keys=None):
+        nonlocal request_count
+        request_count += 1
+        clock.advance(6)
+        if request_count == 3:
+            monitor.latest_data["AABBCCDDEEFF"] = dict(TELEMETRY)
+            monitor._running = False
+
+    monitor._request_status = MagicMock(side_effect=request_status)
+    monitor.authenticate = MagicMock()
+    monitor.connect_mqtt = MagicMock()
+    monitor._run_init_rules = MagicMock()
+    monitor._token_needs_refresh = MagicMock(return_value=False)
+    monitor._try_cloud_recovery = MagicMock()
+    monitor._recover_mqtt_connection = MagicMock()
+
+    with (
+        patch("monitor.time.monotonic", side_effect=clock.monotonic),
+        patch("monitor.time.sleep", side_effect=clock.sleep),
+    ):
+        monitor.run(force_offline=True)
+
+    assert request_count == 3
+    assert clock.sleeps == [3, 4.0, 4.0]
+    assert all(delay >= 0 for delay in clock.sleeps)


### PR DESCRIPTION
## Summary
- add opt-in, persisted Home Assistant kWh sensors for AC input, AC output, and DC output
- publish Energy Dashboard-compatible discovery metadata and document configuration/persistence
- retry incomplete E3600/E3800 local multi-packet reads inside the active poll cycle without stacking cycles
- correct E3600/E3800 telemetry documentation and record the remaining E3600 hardware evidence gap

## Verification
- `ruff format .`
- `ruff check .`
- `python -m pytest -v --cov=. --cov-report=term-missing` — 390 passed, 6 skipped, 20 subtests passed
- `python -m py_compile pecron_monitor.py local_transport.py energy_state.py`
- `python -c "import pecron_monitor, energy_state; print(f'pecron-monitor {pecron_monitor.__version__}')"`

Closes #79
Closes #88