### PR TITLE
Test stale HA energy discovery cleanup

### DIFF
--- a/tests/unit/test_ha_energy_sensors.py
+++ b/tests/unit/test_ha_energy_sensors.py
@@ -67,6 +67,12 @@ def test_energy_discovery_is_opt_in_and_energy_dashboard_compatible(tmp_path):
         if call.args[0].split("/")[-2] in expected and call.args[1]
     ]
     assert disabled_payloads == []
+    cleared_keys = {
+        call.args[0].split("/")[-2]
+        for call in disabled.client.publish.call_args_list
+        if call.args[0].split("/")[-2] in expected and call.args[1] == ""
+    }
+    assert cleared_keys == expected
 
     enabled = _bridge(tmp_path, enabled=True)
     enabled._publish_discovery()


### PR DESCRIPTION
## Summary
- explicitly verify that disabling `homeassistant.energy_sensors` clears all three retained energy discovery topics
- confirms the stale-entity concern raised on #90 is already handled by `ALL_ENTITY_KEYS`

## Verification
- `python -m pytest tests/unit/test_ha_energy_sensors.py -q` — 8 passed
- `ruff format tests/unit/test_ha_energy_sensors.py`
- `ruff check .`

Follow-up to #90.